### PR TITLE
VIP review fixes

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -68,7 +68,7 @@ function settings_screen() {
 	$post_id = get_option( 'adstxt_post' );
 	$post    = false;
 	$content = false;
-	$errors  = false;
+	$errors  = [];
 
 	if ( $post_id ) {
 		$post = get_post( $post_id );

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -68,10 +68,14 @@ function settings_screen() {
 	$post_id = get_option( 'adstxt_post' );
 	$post    = false;
 	$content = false;
+	$errors  = false;
 
 	if ( $post_id ) {
 		$post = get_post( $post_id );
-		$content = isset( $post->post_content ) ? $post->post_content : '';
+	}
+
+	if ( is_a( $post, 'WP_Post' ) ) {
+		$content = $post->post_content;
 		$errors = get_post_meta( $post->ID, 'adstxt_errors', true );
 	}
 ?>

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -14,13 +14,13 @@ function admin_enqueue_scripts( $hook ) {
 		return;
 	}
 
-	wp_enqueue_script( 'adstxt', plugins_url( '/js/admin.js', dirname( __FILE__ ) ), array( 'jquery', 'wp-backbone', 'wp-codemirror' ), false, true );
+	wp_enqueue_script( 'adstxt', esc_url( plugins_url( '/js/admin.js', dirname( __FILE__ ) ) ), array( 'jquery', 'wp-backbone', 'wp-codemirror' ), false, true );
 	wp_enqueue_style( 'code-editor' );
 
 	$strings = array(
-		'saved_message' => __( 'Ads.txt saved', 'ads-txt' ),
-		'error_message' => __( 'Your Ads.txt contains the following issues:', 'ads-txt' ),
-		'unknown_error' => __( 'An unknown error occurred.', 'ads-txt' ),
+		'saved_message' => esc_html__( 'Ads.txt saved', 'ads-txt' ),
+		'error_message' => esc_html__( 'Your Ads.txt contains the following issues:', 'ads-txt' ),
+		'unknown_error' => esc_html__( 'An unknown error occurred.', 'ads-txt' ),
 	);
 
 	wp_localize_script( 'adstxt', 'adstxt', $strings );
@@ -55,7 +55,7 @@ add_action( 'admin_head-settings_page_adstxt-settings', __NAMESPACE__ . '\admin_
  * @return void
  */
 function admin_menu() {
-	add_options_page( __( 'Ads.txt', 'ads-txt' ), __( 'Ads.txt', 'ads-txt' ), 'manage_options', 'adstxt-settings', __NAMESPACE__ . '\settings_screen' );
+	add_options_page( esc_html__( 'Ads.txt', 'ads-txt' ), esc_html__( 'Ads.txt', 'ads-txt' ), 'manage_options', 'adstxt-settings', __NAMESPACE__ . '\settings_screen' );
 }
 add_action( 'admin_menu', __NAMESPACE__ . '\admin_menu' );
 
@@ -82,7 +82,7 @@ function settings_screen() {
 <div class="wrap">
 <?php if ( ! empty( $errors ) ) : ?>
 	<div class="notice notice-error adstxt-notice">
-		<p><strong><?php echo esc_html( __( 'Your Ads.txt contains the following issues:', 'ads-txt' ) ); ?></strong></p>
+		<p><strong><?php echo esc_html__( 'Your Ads.txt contains the following issues:', 'ads-txt' ); ?></strong></p>
 		<ul>
 			<?php
 			foreach ( $errors as $error ) {
@@ -93,14 +93,14 @@ function settings_screen() {
 	</div>
 <?php endif; ?>
 
-	<h2><?php echo esc_html( __( 'Manage Ads.txt', 'ads-txt' ) ); ?></h2>
+	<h2><?php echo esc_html__( 'Manage Ads.txt', 'ads-txt' ); ?></h2>
 
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="adstxt-settings-form">
 		<input type="hidden" name="post_id" value="<?php echo ( is_a( $post, 'WP_Post' ) ? esc_attr( $post->ID ) : '' ); ?>" />
 		<input type="hidden" name="action" value="adstxt-save" />
 		<?php wp_nonce_field( 'adstxt_save' ); ?>
 
-		<label class="screen-reader-text" for="adstxt_content"><?php echo esc_html( __( 'Ads.txt content', 'ads-txt' ) ); ?></label>
+		<label class="screen-reader-text" for="adstxt_content"><?php echo esc_html__( 'Ads.txt content', 'ads-txt' ); ?></label>
 		<textarea class="widefat code" rows="25" name="adstxt" id="adstxt_content"><?php echo esc_textarea( $content ); ?></textarea>
 
 		<div id="adstxt-notification-area"></div>
@@ -135,7 +135,7 @@ function settings_screen() {
 		<p class="adstxt-ays">
 			<input id="adstxt-ays-checkbox" name="adstxt_ays" type="checkbox" value="y" />
 			<label for="adstxt-ays-checkbox">
-				<?php _e( 'Update anyway, even though it may adversely affect your ads?', 'ads-txt' ); ?>
+				<?php esc_html_e( 'Update anyway, even though it may adversely affect your ads?', 'ads-txt' ); ?>
 			</label>
 		</p>
 		<# } #>
@@ -163,7 +163,7 @@ function settings_screen() {
 function format_error( $error ) {
 	/* translators: Error message output. 1: Line number, 2: Error message */
 	$message = sprintf(
-		__( 'Line %1$s: %2$s', 'ads-txt' ),
+		esc_html__( 'Line %1$s: %2$s', 'ads-txt' ),
 		$error['line'],
 		$error['message']
 	);

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -96,7 +96,7 @@ function settings_screen() {
 	<h2><?php echo esc_html( __( 'Manage Ads.txt', 'ads-txt' ) ); ?></h2>
 
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="adstxt-settings-form">
-		<input type="hidden" name="post_id" value="<?php echo ( $post ? esc_attr( $post->ID ) : '' ); ?>" />
+		<input type="hidden" name="post_id" value="<?php echo ( is_a( $post, 'WP_Post' ) ? esc_attr( $post->ID ) : '' ); ?>" />
 		<input type="hidden" name="action" value="adstxt-save" />
 		<?php wp_nonce_field( 'adstxt_save' ); ?>
 

--- a/inc/post-type.php
+++ b/inc/post-type.php
@@ -11,8 +11,8 @@ function register() {
 	register_post_type(
 		'adstxt', array(
 			'labels'           => array(
-				'name'          => _x( 'Ads.txt', 'post type general name', 'ads-txt' ),
-				'singular_name' => _x( 'Ads.txt', 'post type singular name', 'ads-txt' ),
+				'name'          => esc_html_x( 'Ads.txt', 'post type general name', 'ads-txt' ),
+				'singular_name' => esc_html_x( 'Ads.txt', 'post type singular name', 'ads-txt' ),
 			),
 			'public'           => false,
 			'hierarchical'     => false,

--- a/inc/save.php
+++ b/inc/save.php
@@ -98,7 +98,7 @@ function validate_line( $line, $line_number ) {
 			$errors[] = array(
 				'line'    => $line_number,
 				'type'    => 'warning',
-				'message' => __( 'Unrecognized variable', 'ads-txt' ),
+				'message' => esc_html__( 'Unrecognized variable', 'ads-txt' ),
 			);
 		} elseif ( 0 === stripos( $line, 'subdomain=' ) ) { // Subdomains should be, well, subdomains.
 			// Disregard any comments.
@@ -116,8 +116,8 @@ function validate_line( $line, $line_number ) {
 					'type'    => 'warning',
 					'message' => sprintf(
 							/* translators: %s: Subdomain */
-							__( '"%s" does not appear to be a valid subdomain', 'ads-txt' ),
-							esc_html( $subdomain )
+							esc_html__( '"%s" does not appear to be a valid subdomain', 'ads-txt' ),
+							$subdomain
 						),
 				);
 			}
@@ -145,8 +145,8 @@ function validate_line( $line, $line_number ) {
 					'type'    => 'warning',
 					'message' => sprintf(
 							/* translators: %s: Exchange domain */
-							__( '"%s" does not appear to be a valid exchange domain', 'ads-txt' ),
-							esc_html( $exchange )
+							esc_html__( '"%s" does not appear to be a valid exchange domain', 'ads-txt' ),
+							$exchange
 						),
 				);
 			}
@@ -155,7 +155,7 @@ function validate_line( $line, $line_number ) {
 				$errors[] = array(
 					'line'    => $line_number,
 					'type'    => 'error',
-					'message' => __( 'Third field should be RESELLER or DIRECT', 'ads-txt' ),
+					'message' => esc_html__( 'Third field should be RESELLER or DIRECT', 'ads-txt' ),
 				);
 			}
 
@@ -170,8 +170,8 @@ function validate_line( $line, $line_number ) {
 						'type'    => 'warning',
 						'message' => sprintf(
 							/* translators: %s: TAG-ID */
-							__( '"%s" does not appear to be a valid TAG-ID', 'ads-txt' ),
-							esc_html( $fields[3] )
+							esc_html__( '"%s" does not appear to be a valid TAG-ID', 'ads-txt' ),
+							$fields[3]
 						),
 					);
 				}
@@ -186,7 +186,7 @@ function validate_line( $line, $line_number ) {
 			$errors[] = array(
 				'line'    => $line_number,
 				'type'    => 'error',
-				'message' => __( 'Invalid record', 'ads-txt' ),
+				'message' => esc_html__( 'Invalid record', 'ads-txt' ),
 			);
 		}
 


### PR DESCRIPTION
I just reviewed this plugin for a VIP client, and decided to submit a pull request with the fixes. Here's the full list of feedback:


* inc/admin.php:17 - As it becomes output, the URL should be escaped here.
* inc/admin.php:21-23 - Localised strings should be escaped, unless an existing translation is broken by it.
* inc/admin.php:58 - As above, strings should be escaped.
* inc/admin.php:75 - The code here should check that a valid post object is actually returned to avoid errors and unexpected behaviour.
* inc/admin.php:81 - Rather than `esc_html( __() )` it'd be more efficient to use `esc_html__()` here. Not a big deal. 
* inc/admin.php:84 - Before running the foreach, the code should check that `$errors` is definitely an array.
* inc/admin.php:92 - Another place where `esc_html__()` would be more efficient.
* inc/admin.php:95 - It'd be best to tighten up this check to make sure `$post` is definitely a post object. It's existence as a variable doesn't mean that `$post->ID` is going to exist, so the code could still produce errors.
* inc/admin.php:99 - Another place where `esc_html__()` would be more efficient.
* inc/admin.php:134 - The string should be escaped here, using `esc_html_e()`.
* inc/admin.php:162 - The string should be escaped here, using `esc_html__()`.
* inc/post-type.php:14-15 - These strings should be escaped.
* inc/save.php:101 - The string should be escaped here.
* inc/save.php:119 - The string should be escaped here.
* inc/save.php:148 - As above.
* inc/save.php:158 - As above.
* inc/save.php:173 - As above.
* inc/save.php:189 - As above.