### PR TITLE
VIP review fixes, enhanced

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -68,7 +68,7 @@ function settings_screen() {
 	$post_id = get_option( 'adstxt_post' );
 	$post    = false;
 	$content = false;
-	$errors  = false;
+	$errors  = [];
 
 	if ( $post_id ) {
 		$post = get_post( $post_id );

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -150,7 +150,7 @@ function settings_screen() {
 			<# if ( ! _.isUndefined( data.errors.errors ) ) { #>
 			<ul class="adstxt-errors-items">
 			<# _.each( data.errors.errors, function( error ) { #>
-				<?php foreach( get_error_messages() as $error_type => $error_message ) : ?>
+				<?php foreach( array_keys( get_error_messages() ) as $error_type ) : ?>
 				<# if ( "<?php echo esc_html( $error_type ); ?>" === error.type ) { #>
 					<li><?php
 						/*

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -233,15 +233,15 @@ function format_error( $error ) {
  */
 function get_error_messages() {
 	$messages = array(
-		'invalid_variable' => __( 'Unrecognized variable' ),
-		/* translators: %s: Subdomain */
-		'invalid_subdomain' => __( '%s does not appear to be a valid subdomain' ),
-		/* translators: %s: Exchange domain */
-		'invalid_exchange' => __( '%s does not appear to be a valid exchange domain' ),
+		'invalid_variable'     => __( 'Unrecognized variable' ),
+		'invalid_record'       => __( 'Invalid record' ),
 		'invalid_account_type' => __( 'Third field should be RESELLER or DIRECT' ),
+		/* translators: %s: Subdomain */
+		'invalid_subdomain'    => __( '%s does not appear to be a valid subdomain' ),
+		/* translators: %s: Exchange domain */
+		'invalid_exchange'     => __( '%s does not appear to be a valid exchange domain' ),
 		/* translators: %s: Alphanumeric TAG-ID */
-		'invalid_tagid' => __( '%s does not appear to be a valid TAG-ID' ),
-		'invalid_record' => __( 'Invalid record' ),
+		'invalid_tagid'        => __( '%s does not appear to be a valid TAG-ID' ),
 	);
 
 	return $messages;

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -226,6 +226,11 @@ function format_error( $error ) {
 	return $message;
 }
 
+/**
+ * Get all non-generic error messages, translated and with placeholders intact.
+ *
+ * @return array Associative array of error messages.
+ */
 function get_error_messages() {
 	$messages = array(
 		'invalid_variable' => __( 'Unrecognized variable' ),

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -68,10 +68,14 @@ function settings_screen() {
 	$post_id = get_option( 'adstxt_post' );
 	$post    = false;
 	$content = false;
+	$errors  = false;
 
 	if ( $post_id ) {
 		$post = get_post( $post_id );
-		$content = isset( $post->post_content ) ? $post->post_content : '';
+	}
+
+	if ( is_a( $post, 'WP_Post' ) ) {
+		$content = $post->post_content;
 		$errors = get_post_meta( $post->ID, 'adstxt_errors', true );
 	}
 ?>

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -76,7 +76,7 @@ function settings_screen() {
 
 	if ( is_a( $post, 'WP_Post' ) ) {
 		$content = $post->post_content;
-		$errors = get_post_meta( $post->ID, 'adstxt_errors', true );
+		$errors  = get_post_meta( $post->ID, 'adstxt_errors', true );
 	}
 ?>
 <div class="wrap">
@@ -91,8 +91,8 @@ function settings_screen() {
 				// Errors were originally stored as an array
 				// This old style only needs to be accounted for here at runtime display
 				if ( isset( $error['message'] ) ) {
-					/* translators: Error message output. 1: Line number, 2: Error message */
 					$message = sprintf(
+						/* translators: Error message output. 1: Line number, 2: Error message */
 						__( 'Line %1$s: %2$s', 'ads-txt' ),
 						$error['line'],
 						$error['message']
@@ -108,7 +108,7 @@ function settings_screen() {
 					 * We don't have good JS translation tools yet and it's better to avoid duplication,
 					 * so we use a single PHP function for both the JS template and in PHP.
 					 */
-					echo format_error( $error );
+					echo format_error( $error ); // WPCS: XSS ok.
 				}
 
 				echo  '</li>';
@@ -150,9 +150,10 @@ function settings_screen() {
 			<# if ( ! _.isUndefined( data.errors.errors ) ) { #>
 			<ul class="adstxt-errors-items">
 			<# _.each( data.errors.errors, function( error ) { #>
-				<?php foreach( array_keys( get_error_messages() ) as $error_type ) : ?>
+				<?php foreach ( array_keys( get_error_messages() ) as $error_type ) : ?>
 				<# if ( "<?php echo esc_html( $error_type ); ?>" === error.type ) { #>
-					<li><?php
+					<li>
+						<?php
 						/*
 						 * Important: This is escaped piece-wise inside `format_error()`,
 						 * as we cannot do absolute-end late escaping as normally recommended.
@@ -161,12 +162,13 @@ function settings_screen() {
 						 * We don't have good JS translation tools yet and it's better to avoid duplication,
 						 * so we have to get them already-translated from PHP.
 						 */
-						echo format_error( array(
-							'line' => '{{error.line}}',
-							'type' => $error_type,
+						echo format_error( array( // WPCS: XSS ok.
+							'line'  => '{{error.line}}',
+							'type'  => $error_type,
 							'value' => '{{error.value}}',
 						) );
-					?></li>
+						?>
+					</li>
 				<# } #>
 				<?php endforeach; ?>
 			<# } ); #>
@@ -210,14 +212,14 @@ function format_error( $error ) {
 		return __( 'Unknown error', 'adstxt' );
 	}
 
-	if ( ! isset( $error['value' ] ) ) {
-		$error['value' ] = '';
+	if ( ! isset( $error['value'] ) ) {
+		$error['value'] = '';
 	}
 
 	$message = sprintf( esc_html( $messages[ $error['type'] ] ), '<code>' . esc_html( $error['value'] ) . '</code>' );
 
-	/* translators: Error message output. 1: Line number, 2: Error message */
 	$message = sprintf(
+		/* translators: Error message output. 1: Line number, 2: Error message */
 		__( 'Line %1$s: %2$s', 'ads-txt' ),
 		esc_html( $error['line'] ),
 		$message // This is escaped piece-wise above and may contain HTML (code tags) at this point

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -14,13 +14,13 @@ function admin_enqueue_scripts( $hook ) {
 		return;
 	}
 
-	wp_enqueue_script( 'adstxt', plugins_url( '/js/admin.js', dirname( __FILE__ ) ), array( 'jquery', 'wp-backbone', 'wp-codemirror' ), false, true );
+	wp_enqueue_script( 'adstxt', esc_url( plugins_url( '/js/admin.js', dirname( __FILE__ ) ) ), array( 'jquery', 'wp-backbone', 'wp-codemirror' ), false, true );
 	wp_enqueue_style( 'code-editor' );
 
 	$strings = array(
-		'saved_message' => __( 'Ads.txt saved', 'ads-txt' ),
-		'error_message' => __( 'Your Ads.txt contains the following issues:', 'ads-txt' ),
-		'unknown_error' => __( 'An unknown error occurred.', 'ads-txt' ),
+		'saved_message' => esc_html__( 'Ads.txt saved', 'ads-txt' ),
+		'error_message' => esc_html__( 'Your Ads.txt contains the following issues:', 'ads-txt' ),
+		'unknown_error' => esc_html__( 'An unknown error occurred.', 'ads-txt' ),
 	);
 
 	wp_localize_script( 'adstxt', 'adstxt', $strings );
@@ -55,7 +55,7 @@ add_action( 'admin_head-settings_page_adstxt-settings', __NAMESPACE__ . '\admin_
  * @return void
  */
 function admin_menu() {
-	add_options_page( __( 'Ads.txt', 'ads-txt' ), __( 'Ads.txt', 'ads-txt' ), 'manage_options', 'adstxt-settings', __NAMESPACE__ . '\settings_screen' );
+	add_options_page( esc_html__( 'Ads.txt', 'ads-txt' ), esc_html__( 'Ads.txt', 'ads-txt' ), 'manage_options', 'adstxt-settings', __NAMESPACE__ . '\settings_screen' );
 }
 add_action( 'admin_menu', __NAMESPACE__ . '\admin_menu' );
 
@@ -82,7 +82,7 @@ function settings_screen() {
 <div class="wrap">
 <?php if ( ! empty( $errors ) ) : ?>
 	<div class="notice notice-error adstxt-notice">
-		<p><strong><?php echo esc_html( __( 'Your Ads.txt contains the following issues:', 'ads-txt' ) ); ?></strong></p>
+		<p><strong><?php echo esc_html__( 'Your Ads.txt contains the following issues:', 'ads-txt' ); ?></strong></p>
 		<ul>
 			<?php
 			foreach ( $errors as $error ) {
@@ -93,14 +93,14 @@ function settings_screen() {
 	</div>
 <?php endif; ?>
 
-	<h2><?php echo esc_html( __( 'Manage Ads.txt', 'ads-txt' ) ); ?></h2>
+	<h2><?php echo esc_html__( 'Manage Ads.txt', 'ads-txt' ); ?></h2>
 
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="adstxt-settings-form">
 		<input type="hidden" name="post_id" value="<?php echo ( is_a( $post, 'WP_Post' ) ? esc_attr( $post->ID ) : '' ); ?>" />
 		<input type="hidden" name="action" value="adstxt-save" />
 		<?php wp_nonce_field( 'adstxt_save' ); ?>
 
-		<label class="screen-reader-text" for="adstxt_content"><?php echo esc_html( __( 'Ads.txt content', 'ads-txt' ) ); ?></label>
+		<label class="screen-reader-text" for="adstxt_content"><?php echo esc_html__( 'Ads.txt content', 'ads-txt' ); ?></label>
 		<textarea class="widefat code" rows="25" name="adstxt" id="adstxt_content"><?php echo esc_textarea( $content ); ?></textarea>
 
 		<div id="adstxt-notification-area"></div>
@@ -135,7 +135,7 @@ function settings_screen() {
 		<p class="adstxt-ays">
 			<input id="adstxt-ays-checkbox" name="adstxt_ays" type="checkbox" value="y" />
 			<label for="adstxt-ays-checkbox">
-				<?php _e( 'Update anyway, even though it may adversely affect your ads?', 'ads-txt' ); ?>
+				<?php esc_html_e( 'Update anyway, even though it may adversely affect your ads?', 'ads-txt' ); ?>
 			</label>
 		</p>
 		<# } #>
@@ -163,7 +163,7 @@ function settings_screen() {
 function format_error( $error ) {
 	/* translators: Error message output. 1: Line number, 2: Error message */
 	$message = sprintf(
-		__( 'Line %1$s: %2$s', 'ads-txt' ),
+		esc_html__( 'Line %1$s: %2$s', 'ads-txt' ),
 		$error['line'],
 		$error['message']
 	);

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -96,7 +96,7 @@ function settings_screen() {
 	<h2><?php echo esc_html( __( 'Manage Ads.txt', 'ads-txt' ) ); ?></h2>
 
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="adstxt-settings-form">
-		<input type="hidden" name="post_id" value="<?php echo ( $post ? esc_attr( $post->ID ) : '' ); ?>" />
+		<input type="hidden" name="post_id" value="<?php echo ( is_a( $post, 'WP_Post' ) ? esc_attr( $post->ID ) : '' ); ?>" />
 		<input type="hidden" name="action" value="adstxt-save" />
 		<?php wp_nonce_field( 'adstxt_save' ); ?>
 

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -207,7 +207,7 @@ function format_error( $error ) {
 	$messages = get_error_messages();
 
 	if ( ! isset( $messages[ $error['type'] ] ) ) {
-		return __( 'Unknown error.', 'adstxt' );
+		return __( 'Unknown error', 'adstxt' );
 	}
 
 	if ( ! isset( $error['value' ] ) ) {

--- a/inc/post-type.php
+++ b/inc/post-type.php
@@ -11,8 +11,8 @@ function register() {
 	register_post_type(
 		'adstxt', array(
 			'labels'           => array(
-				'name'          => _x( 'Ads.txt', 'post type general name', 'ads-txt' ),
-				'singular_name' => _x( 'Ads.txt', 'post type singular name', 'ads-txt' ),
+				'name'          => esc_html_x( 'Ads.txt', 'post type general name', 'ads-txt' ),
+				'singular_name' => esc_html_x( 'Ads.txt', 'post type singular name', 'ads-txt' ),
 			),
 			'public'           => false,
 			'hierarchical'     => false,

--- a/inc/save.php
+++ b/inc/save.php
@@ -110,8 +110,8 @@ function validate_line( $line, $line_number ) {
 			if ( 1 !== count( $subdomain ) || ! preg_match( $domain_regex, $subdomain[0] ) ) {
 				$subdomain = implode( '', $subdomain );
 				$errors[] = array(
-					'line' => $line_number,
-					'type' => 'invalid_subdomain',
+					'line'  => $line_number,
+					'type'  => 'invalid_subdomain',
 					'value' => $subdomain,
 				);
 			}
@@ -135,8 +135,8 @@ function validate_line( $line, $line_number ) {
 
 			if ( ! preg_match( $domain_regex, $exchange ) ) {
 				$errors[] = array(
-					'line' => $line_number,
-					'type' => 'invalid_exchange',
+					'line'  => $line_number,
+					'type'  => 'invalid_exchange',
 					'value' => $exchange,
 				);
 			}
@@ -155,8 +155,8 @@ function validate_line( $line, $line_number ) {
 				// TAG-IDs are meant to be checked against their DB - perhaps good for a service or the future.
 				if ( ! empty( $tag_id ) && ! preg_match( '/^[a-f0-9]{16}$/', $tag_id ) ) {
 					$errors[] = array(
-						'line' => $line_number,
-						'type' => 'invalid_tagid',
+						'line'  => $line_number,
+						'type'  => 'invalid_tagid',
 						'value' => $fields[3],
 					);
 				}

--- a/inc/save.php
+++ b/inc/save.php
@@ -59,8 +59,7 @@ function save() {
 		$response['sanitized'] = $sanitized;
 
 		if ( ! empty( $errors ) ) {
-			// Transform errors into strings for easier i18n.
-			$response['errors'] = array_map( __NAMESPACE__ . '\format_error', $errors );
+			$response['errors'] = $errors;
 		}
 
 		echo wp_json_encode( $response );
@@ -96,9 +95,8 @@ function validate_line( $line, $line_number ) {
 		// The spec currently supports CONTACT and SUBDOMAIN.
 		if ( ! preg_match( '/^(CONTACT|SUBDOMAIN)=/i', $line ) ) {
 			$errors[] = array(
-				'line'    => $line_number,
-				'type'    => 'warning',
-				'message' => esc_html__( 'Unrecognized variable', 'ads-txt' ),
+				'line' => $line_number,
+				'type' => 'invalid_variable',
 			);
 		} elseif ( 0 === stripos( $line, 'subdomain=' ) ) { // Subdomains should be, well, subdomains.
 			// Disregard any comments.
@@ -112,13 +110,9 @@ function validate_line( $line, $line_number ) {
 			if ( 1 !== count( $subdomain ) || ! preg_match( $domain_regex, $subdomain[0] ) ) {
 				$subdomain = implode( '', $subdomain );
 				$errors[] = array(
-					'line'    => $line_number,
-					'type'    => 'warning',
-					'message' => sprintf(
-							/* translators: %s: Subdomain */
-							esc_html__( '"%s" does not appear to be a valid subdomain', 'ads-txt' ),
-							$subdomain
-						),
+					'line' => $line_number,
+					'type' => 'invalid_subdomain',
+					'value' => $subdomain,
 				);
 			}
 		}
@@ -141,21 +135,16 @@ function validate_line( $line, $line_number ) {
 
 			if ( ! preg_match( $domain_regex, $exchange ) ) {
 				$errors[] = array(
-					'line'    => $line_number,
-					'type'    => 'warning',
-					'message' => sprintf(
-							/* translators: %s: Exchange domain */
-							esc_html__( '"%s" does not appear to be a valid exchange domain', 'ads-txt' ),
-							$exchange
-						),
+					'line' => $line_number,
+					'type' => 'invalid_exchange',
+					'value' => $exchange,
 				);
 			}
 
 			if ( ! preg_match( '/^(RESELLER|DIRECT)$/i', $account_type ) ) {
 				$errors[] = array(
-					'line'    => $line_number,
-					'type'    => 'error',
-					'message' => esc_html__( 'Third field should be RESELLER or DIRECT', 'ads-txt' ),
+					'line' => $line_number,
+					'type' => 'invalid_account_type',
 				);
 			}
 
@@ -166,13 +155,9 @@ function validate_line( $line, $line_number ) {
 				// TAG-IDs are meant to be checked against their DB - perhaps good for a service or the future.
 				if ( ! empty( $tag_id ) && ! preg_match( '/^[a-f0-9]{16}$/', $tag_id ) ) {
 					$errors[] = array(
-						'line'    => $line_number,
-						'type'    => 'warning',
-						'message' => sprintf(
-							/* translators: %s: TAG-ID */
-							esc_html__( '"%s" does not appear to be a valid TAG-ID', 'ads-txt' ),
-							$fields[3]
-						),
+						'line' => $line_number,
+						'type' => 'invalid_tagid',
+						'value' => $fields[3],
 					);
 				}
 			}
@@ -184,9 +169,8 @@ function validate_line( $line, $line_number ) {
 			$sanitized = wp_strip_all_tags( $line );
 
 			$errors[] = array(
-				'line'    => $line_number,
-				'type'    => 'error',
-				'message' => esc_html__( 'Invalid record', 'ads-txt' ),
+				'line' => $line_number,
+				'type' => 'invalid_record',
 			);
 		}
 

--- a/inc/save.php
+++ b/inc/save.php
@@ -21,7 +21,9 @@ function save() {
 
 	// Different browsers use different line endings.
 	$lines     = preg_split( '/\r\n|\r|\n/', $_post['adstxt'] );
-	$sanitized = $errors = $response = array();
+	$sanitized = array();
+	$errors    = array();
+	$response  = array();
 
 	foreach ( $lines as $i => $line ) {
 		$line_number = $i + 1;
@@ -66,7 +68,7 @@ function save() {
 		die();
 	}
 
-	wp_redirect( esc_url_raw( $_POST['_wp_http_referer'] ) . '&updated=true' );
+	wp_safe_redirect( esc_url_raw( $_post['_wp_http_referer'] ) . '&updated=true' );
 	exit;
 }
 add_action( 'admin_post_adstxt-save', __NAMESPACE__ . '\save' );
@@ -109,7 +111,7 @@ function validate_line( $line, $line_number ) {
 			// If there's anything other than one piece left something's not right.
 			if ( 1 !== count( $subdomain ) || ! preg_match( $domain_regex, $subdomain[0] ) ) {
 				$subdomain = implode( '', $subdomain );
-				$errors[] = array(
+				$errors[]  = array(
 					'line'  => $line_number,
 					'type'  => 'invalid_subdomain',
 					'value' => $subdomain,

--- a/inc/save.php
+++ b/inc/save.php
@@ -98,7 +98,7 @@ function validate_line( $line, $line_number ) {
 			$errors[] = array(
 				'line'    => $line_number,
 				'type'    => 'warning',
-				'message' => __( 'Unrecognized variable', 'ads-txt' ),
+				'message' => esc_html__( 'Unrecognized variable', 'ads-txt' ),
 			);
 		} elseif ( 0 === stripos( $line, 'subdomain=' ) ) { // Subdomains should be, well, subdomains.
 			// Disregard any comments.
@@ -116,8 +116,8 @@ function validate_line( $line, $line_number ) {
 					'type'    => 'warning',
 					'message' => sprintf(
 							/* translators: %s: Subdomain */
-							__( '"%s" does not appear to be a valid subdomain', 'ads-txt' ),
-							esc_html( $subdomain )
+							esc_html__( '"%s" does not appear to be a valid subdomain', 'ads-txt' ),
+							$subdomain
 						),
 				);
 			}
@@ -145,8 +145,8 @@ function validate_line( $line, $line_number ) {
 					'type'    => 'warning',
 					'message' => sprintf(
 							/* translators: %s: Exchange domain */
-							__( '"%s" does not appear to be a valid exchange domain', 'ads-txt' ),
-							esc_html( $exchange )
+							esc_html__( '"%s" does not appear to be a valid exchange domain', 'ads-txt' ),
+							$exchange
 						),
 				);
 			}
@@ -155,7 +155,7 @@ function validate_line( $line, $line_number ) {
 				$errors[] = array(
 					'line'    => $line_number,
 					'type'    => 'error',
-					'message' => __( 'Third field should be RESELLER or DIRECT', 'ads-txt' ),
+					'message' => esc_html__( 'Third field should be RESELLER or DIRECT', 'ads-txt' ),
 				);
 			}
 
@@ -170,8 +170,8 @@ function validate_line( $line, $line_number ) {
 						'type'    => 'warning',
 						'message' => sprintf(
 							/* translators: %s: TAG-ID */
-							__( '"%s" does not appear to be a valid TAG-ID', 'ads-txt' ),
-							esc_html( $fields[3] )
+							esc_html__( '"%s" does not appear to be a valid TAG-ID', 'ads-txt' ),
+							$fields[3]
 						),
 					);
 				}
@@ -186,7 +186,7 @@ function validate_line( $line, $line_number ) {
 			$errors[] = array(
 				'line'    => $line_number,
 				'type'    => 'error',
-				'message' => __( 'Invalid record', 'ads-txt' ),
+				'message' => esc_html__( 'Invalid record', 'ads-txt' ),
 			);
 		}
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -61,7 +61,7 @@
 	});
 
 	$( '.wrap' ).on( 'click', '#adstxt-ays-checkbox', function( e ) {
-		if ( true === $( this ).prop('checked') ) {
+		if ( true === $( this ).prop( 'checked' ) ) {
 			submit.removeAttr( 'disabled' );
 		} else {
 			submit.attr( 'disabled', 'disabled' );


### PR DESCRIPTION
This supplants #17, which was escaping double quotes in error messages. That bug reminded me that my original desire was to wrap the values within error message in `<code>` tags to make them easier to see, which was left by the wayside somewhere. It was a fair bit of working through the logic, but I think this works now without duplication between PHP and JS to have properly translated _and_ escaped messages.

@philipjohn - could you kindly leave a comment if you're able to review the pull request here? If not, we'll submit back to VIP via the usual ways and then merge this into the public release once that's fully worked through and approved. Thanks so much for starting this.