### PR TITLE
Add a notice to the edit screen if ads.txt already exists on the server

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -44,9 +44,6 @@ function admin_head_css() {
 	border: 1px solid #ddd;
 	box-sizing: border-box;
 }
-.existing-adstxt {
-	display: none;
-}
 </style>
 <?php
 }
@@ -84,10 +81,14 @@ function settings_screen() {
 ?>
 <div class="wrap">
 
-	<div class="notice notice-error adstxt-notice existing-adstxt">
-		<p><strong><?php echo esc_html_e( 'Existing Ads.txt file found', 'ads-txt' ); ?></strong></p>
-		<p><?php echo esc_html_e( 'You will need to rename or remove the existing ads.txt file before you will be able to see any changes you make to ads.txt inside the WordPress admin.', 'ads-txt' ); ?></p>
-	</div>
+	<?php if ( ads_txt_exists() ) : ?>
+		<div class="notice notice-error adstxt-notice existing-adstxt">
+			<p><strong><?php echo esc_html_e( 'Existing Ads.txt file found', 'ads-txt' ); ?></strong></p>
+			<p><?php echo esc_html_e( 'You will need to rename or remove the existing ads.txt file before you will be able to see any changes you make to ads.txt inside the WordPress admin.', 'ads-txt' ); ?></p>
+
+			<p><?php echo esc_html_e('Removed the existing ads.txt but are still seeing this warning?', 'ads-txt') ?> <a class="ads-txt-rerun-check" href="#"><?php echo esc_html_e('Re-run the check now', 'ads-txt'); ?></a></p>
+		</div>
+	<?php endif; ?>
 
 <?php if ( ! empty( $errors ) ) : ?>	
 	<div class="notice notice-error adstxt-notice">
@@ -256,4 +257,21 @@ function get_error_messages() {
 	);
 
 	return $messages;
+}
+
+/**
+ * Check whether there is an existing ads.txt file that will override the plugin output.
+ *
+ * @return bool Value of whether ads.txt already exists
+ */
+function ads_txt_exists() {
+	// No-op on WordPress.com
+	if ( defined( 'WPCOM_IS_VIP_ENV' ) && WPCOM_IS_VIP_ENV ) {
+		return;
+	}
+
+	$ads_txt_path = get_site_url() . '/ads.txt';
+
+	// Return true if file exists, otherwise return false
+	return wp_remote_get($ads_txt_path)['response']['code'] == 200;
 }

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -86,7 +86,7 @@ function settings_screen() {
 			<p><strong><?php echo esc_html_e( 'Existing Ads.txt file found', 'ads-txt' ); ?></strong></p>
 			<p><?php echo esc_html_e( 'You will need to rename or remove the existing ads.txt file before you will be able to see any changes you make to ads.txt inside the WordPress admin.', 'ads-txt' ); ?></p>
 
-			<p><?php echo esc_html_e('Removed the existing ads.txt but are still seeing this warning?', 'ads-txt') ?> <a class="ads-txt-rerun-check" href="#"><?php echo esc_html_e('Re-run the check now', 'ads-txt'); ?></a></p>
+			<p><?php echo esc_html_e( 'Removed the existing ads.txt but are still seeing this warning?', 'ads-txt' ); ?> <a class="ads-txt-rerun-check" href="#"><?php echo esc_html_e( 'Re-run the check now', 'ads-txt' ); ?></a></p>
 		</div>
 	<?php endif; ?>
 
@@ -273,5 +273,5 @@ function ads_txt_exists() {
 	$ads_txt_path = get_site_url() . '/ads.txt';
 
 	// Return true if file exists, otherwise return false
-	return wp_remote_get($ads_txt_path)['response']['code'] == 200;
+	return 200 == wp_remote_get( $ads_txt_path )['response']['code'];
 }

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -84,8 +84,8 @@ function settings_screen() {
 <?php if ( ads_txt_exists() ) : ?>
 
 	<div class="notice notice-error adstxt-notice">
-		<p><strong>WARNING: EXISTING ADS.TXT FILE FOUND</strong></p>
-		<p>We found an existing ads.txt file on your server. You will need to rename or remove the existing ads.txt file before you will be able to see any changes you make to ads.txt inside the WordPress admin.</p>
+		<p><strong><?php echo esc_html_e( 'Existing Ads.txt file found', 'ads-txt' ); ?></strong></p>
+		<p><?php echo esc_html_e( 'You will need to rename or remove the existing ads.txt file before you will be able to see any changes you make to ads.txt inside the WordPress admin.', 'ads-txt' ); ?></p>
 	</div>
 
 <?php endif; ?>

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -44,6 +44,9 @@ function admin_head_css() {
 	border: 1px solid #ddd;
 	box-sizing: border-box;
 }
+.existing-adstxt {
+	display: none;
+}
 </style>
 <?php
 }
@@ -81,14 +84,10 @@ function settings_screen() {
 ?>
 <div class="wrap">
 
-<?php if ( ads_txt_exists() ) : ?>
-
-	<div class="notice notice-error adstxt-notice">
+	<div class="notice notice-error adstxt-notice existing-adstxt">
 		<p><strong><?php echo esc_html_e( 'Existing Ads.txt file found', 'ads-txt' ); ?></strong></p>
 		<p><?php echo esc_html_e( 'You will need to rename or remove the existing ads.txt file before you will be able to see any changes you make to ads.txt inside the WordPress admin.', 'ads-txt' ); ?></p>
 	</div>
-
-<?php endif; ?>
 
 <?php if ( ! empty( $errors ) ) : ?>	
 	<div class="notice notice-error adstxt-notice">
@@ -257,18 +256,4 @@ function get_error_messages() {
 	);
 
 	return $messages;
-}
-
-/**
- * Check whether there is an existing ads.txt file that will override the plugin output.
- *
- * @return bool Value of whether ads.txt already exists
- */
-function ads_txt_exists() {
-	// No-op on WordPress.com
-	if ( defined( 'WPCOM_IS_VIP_ENV' ) && WPCOM_IS_VIP_ENV ) {
-		return;
-	}
-
-	return file_exists( $_SERVER['DOCUMENT_ROOT'] . '/ads.txt' );
 }

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -86,7 +86,7 @@ function settings_screen() {
 			<p><strong><?php echo esc_html_e( 'Existing Ads.txt file found', 'ads-txt' ); ?></strong></p>
 			<p><?php echo esc_html_e( 'You will need to rename or remove the existing ads.txt file before you will be able to see any changes you make to ads.txt inside the WordPress admin.', 'ads-txt' ); ?></p>
 
-			<p><?php echo esc_html_e( 'Removed the existing ads.txt but are still seeing this warning?', 'ads-txt' ); ?> <a class="ads-txt-rerun-check" href="#"><?php echo esc_html_e( 'Re-run the check now', 'ads-txt' ); ?></a></p>
+			<p><?php echo esc_html_e( 'Removed the existing ads.txt but are still seeing this warning?', 'ads-txt' ); ?> <button class="ads-txt-rerun-check"><?php echo esc_html_e( 'Re-run the check now', 'ads-txt' ); ?></button></p>
 		</div>
 	<?php endif; ?>
 

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -85,7 +85,7 @@ function settings_screen() {
 		<p><strong><?php echo esc_html_e( 'Existing Ads.txt file found', 'ads-txt' ); ?></strong></p>
 		<p><?php echo esc_html_e( 'You will need to rename or remove the existing ads.txt file before you will be able to see any changes you make to ads.txt inside the WordPress admin.', 'ads-txt' ); ?></p>
 
-		<p><?php echo esc_html_e( 'Removed the existing ads.txt but are still seeing this warning?', 'ads-txt' ); ?> <a class="ads-txt-rerun-check" href="#"><?php echo esc_html_e( 'Re-run the check now', 'ads-txt' ); ?></a></p>
+		<p><?php echo esc_html_e( 'Removed the existing ads.txt but are still seeing this warning?', 'ads-txt' ); ?> <a class="ads-txt-rerun-check" href="#"><?php echo esc_html_e( 'Re-run the check now', 'ads-txt' ); ?></a> <span class="spinner" style="float:none;margin:-2px 5px 0"></span></p>
 	</div>
 
 <?php if ( ! empty( $errors ) ) : ?>	

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -265,7 +265,10 @@ function get_error_messages() {
  * @return bool Value of whether ads.txt already exists
  */
 function ads_txt_exists() {
+	// No-op on WordPress.com
+	if ( defined( 'WPCOM_IS_VIP_ENV' ) && WPCOM_IS_VIP_ENV ) {
+		return;
+	}
 
 	return file_exists( $_SERVER['DOCUMENT_ROOT'] . '/ads.txt' );
-
 }

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -83,9 +83,9 @@ function settings_screen() {
 
 	<div class="notice notice-error adstxt-notice existing-adstxt" style="display: none;">
 		<p><strong><?php echo esc_html_e( 'Existing Ads.txt file found', 'ads-txt' ); ?></strong></p>
-		<p><?php echo esc_html_e( 'You will need to rename or remove the existing ads.txt file before you will be able to see any changes you make to ads.txt inside the WordPress admin.', 'ads-txt' ); ?></p>
+		<p><?php echo esc_html_e( 'An ads.txt file on the server will take precedence over any content entered here. You will need to rename or remove the existing ads.txt file before you will be able to see any changes you make on this screen.', 'ads-txt' ); ?></p>
 
-		<p><?php echo esc_html_e( 'Removed the existing ads.txt but are still seeing this warning?', 'ads-txt' ); ?> <a class="ads-txt-rerun-check" href="#"><?php echo esc_html_e( 'Re-run the check now', 'ads-txt' ); ?></a> <span class="spinner" style="float:none;margin:-2px 5px 0"></span></p>
+		<p><?php echo esc_html_e( 'Removed the existing file but are still seeing this warning?', 'ads-txt' ); ?> <a class="ads-txt-rerun-check" href="#"><?php echo esc_html_e( 'Re-run the check now', 'ads-txt' ); ?></a> <span class="spinner" style="float:none;margin:-2px 5px 0"></span></p>
 	</div>
 
 <?php if ( ! empty( $errors ) ) : ?>	

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -80,7 +80,17 @@ function settings_screen() {
 	}
 ?>
 <div class="wrap">
-<?php if ( ! empty( $errors ) ) : ?>
+
+<?php if ( ads_txt_exists() ) : ?>
+
+	<div class="notice notice-error adstxt-notice">
+		<p><strong>WARNING: EXISTING ADS.TXT FILE FOUND</strong></p>
+		<p>We found an existing ads.txt file on your server. You will need to rename or remove the existing ads.txt file before you will be able to see any changes you make to ads.txt inside the WordPress admin.</p>
+	</div>
+
+<?php endif; ?>
+
+<?php if ( ! empty( $errors ) ) : ?>	
 	<div class="notice notice-error adstxt-notice">
 		<p><strong><?php echo esc_html__( 'Your Ads.txt contains the following issues:', 'ads-txt' ); ?></strong></p>
 		<ul>
@@ -247,4 +257,15 @@ function get_error_messages() {
 	);
 
 	return $messages;
+}
+
+/**
+ * Check whether there is an existing ads.txt file that will override the plugin output.
+ *
+ * @return bool Value of whether ads.txt already exists
+ */
+function ads_txt_exists() {
+
+	return file_exists( $_SERVER['DOCUMENT_ROOT'] . '/ads.txt' );
+
 }

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -81,14 +81,12 @@ function settings_screen() {
 ?>
 <div class="wrap">
 
-	<?php if ( ads_txt_exists() ) : ?>
-		<div class="notice notice-error adstxt-notice existing-adstxt">
-			<p><strong><?php echo esc_html_e( 'Existing Ads.txt file found', 'ads-txt' ); ?></strong></p>
-			<p><?php echo esc_html_e( 'You will need to rename or remove the existing ads.txt file before you will be able to see any changes you make to ads.txt inside the WordPress admin.', 'ads-txt' ); ?></p>
+	<div class="notice notice-error adstxt-notice existing-adstxt" style="display: none;">
+		<p><strong><?php echo esc_html_e( 'Existing Ads.txt file found', 'ads-txt' ); ?></strong></p>
+		<p><?php echo esc_html_e( 'You will need to rename or remove the existing ads.txt file before you will be able to see any changes you make to ads.txt inside the WordPress admin.', 'ads-txt' ); ?></p>
 
-			<p><?php echo esc_html_e( 'Removed the existing ads.txt but are still seeing this warning?', 'ads-txt' ); ?> <button class="ads-txt-rerun-check"><?php echo esc_html_e( 'Re-run the check now', 'ads-txt' ); ?></button></p>
-		</div>
-	<?php endif; ?>
+		<p><?php echo esc_html_e( 'Removed the existing ads.txt but are still seeing this warning?', 'ads-txt' ); ?> <a class="ads-txt-rerun-check" href="#"><?php echo esc_html_e( 'Re-run the check now', 'ads-txt' ); ?></a></p>
+	</div>
 
 <?php if ( ! empty( $errors ) ) : ?>	
 	<div class="notice notice-error adstxt-notice">
@@ -257,21 +255,4 @@ function get_error_messages() {
 	);
 
 	return $messages;
-}
-
-/**
- * Check whether there is an existing ads.txt file that will override the plugin output.
- *
- * @return bool Value of whether ads.txt already exists
- */
-function ads_txt_exists() {
-	// No-op on WordPress.com
-	if ( defined( 'WPCOM_IS_VIP_ENV' ) && WPCOM_IS_VIP_ENV ) {
-		return;
-	}
-
-	$ads_txt_path = get_site_url() . '/ads.txt';
-
-	// Return true if file exists, otherwise return false
-	return 200 == wp_remote_get( $ads_txt_path )['response']['code'];
 }

--- a/js/admin.js
+++ b/js/admin.js
@@ -7,10 +7,14 @@
 			mode: 'shell'
 		} );
 
-	function checkForAdsFile(){
+	function checkForAdsFile( e ){
 		var currentTime = Date.now(),
 			adstxtUrl = '/ads.txt?currentTime=' + currentTime,
 			spinner = $( '.existing-adstxt .spinner' );
+
+		if ( false !== e ) {
+			e.preventDefault();
+		}
 		
 		spinner.addClass( 'is-active' );
 
@@ -24,7 +28,7 @@
 	}
 	
 	// Call our check when we first load the page
-	checkForAdsFile();
+	checkForAdsFile( false );
 
 	$( '.ads-txt-rerun-check' ).on( 'click', checkForAdsFile );
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -8,10 +8,14 @@
 		} );
 
 	function checkForAdsFile(){
-		var currentTime = Date.now();
-		var adstxtUrl = '/ads.txt?currentTime=' + currentTime;
+		var currentTime = Date.now(),
+			adstxtUrl = '/ads.txt?currentTime=' + currentTime,
+			spinner = $( '.existing-adstxt .spinner' );
+		
+		spinner.addClass( 'is-active' );
 
 		$.get( adstxtUrl, function( data, status ){
+			spinner.removeClass( 'is-active' );
 			$( '.existing-adstxt' ).show();
 		} ).fail( function() {
 			// Ads.txt not found

--- a/js/admin.js
+++ b/js/admin.js
@@ -8,7 +8,10 @@
 		} );
 
 	function checkForAdsFile(){
-		$.get('/ads.txt', function( data, status ){
+		var currentTime = (new Date()).getTime();
+		var adstxtUrl = '/ads.txt?currentTime=' + currentTime;
+
+		$.get(adstxtUrl, function( data, status ){
 			$('.existing-adstxt').show();
 		}).fail(function(){
 			// Ads.txt not found

--- a/js/admin.js
+++ b/js/admin.js
@@ -7,11 +7,13 @@
 			mode: 'shell'
 		} );
 
-	$.get('/ads.txt', function( data, status ){
-		$('.existing-adstxt').show();
-	}).fail(function(){
-		// Ads.txt not found
-		$('.existing-adstxt').hide();
+	$('.ads-txt-rerun-check').click(function(){
+		$.get('/ads.txt', function( data, status ){
+			$('.existing-adstxt').show();
+		}).fail(function(){
+			// Ads.txt not found
+			$('.existing-adstxt').hide();
+		});
 	});
 
 	submit.on( 'click', function( e ){

--- a/js/admin.js
+++ b/js/admin.js
@@ -8,21 +8,21 @@
 		} );
 
 	function checkForAdsFile(){
-		var currentTime = (new Date()).getTime();
+		var currentTime = Date.now();
 		var adstxtUrl = '/ads.txt?currentTime=' + currentTime;
 
-		$.get(adstxtUrl, function( data, status ){
-			$('.existing-adstxt').show();
-		}).fail(function(){
+		$.get( adstxtUrl, function( data, status ){
+			$( '.existing-adstxt' ).show();
+		} ).fail( function() {
 			// Ads.txt not found
-			$('.existing-adstxt').hide();
+			$( '.existing-adstxt' ).hide();
 		});
 	}
 	
 	// Call our check when we first load the page
 	checkForAdsFile();
 
-	$('.ads-txt-rerun-check').click( checkForAdsFile );
+	$( '.ads-txt-rerun-check' ).on( 'click', checkForAdsFile );
 
 	submit.on( 'click', function( e ){
 		e.preventDefault();

--- a/js/admin.js
+++ b/js/admin.js
@@ -7,6 +7,13 @@
 			mode: 'shell'
 		} );
 
+	$.get('/ads.txt', function( data, status ){
+		$('.existing-adstxt').show();
+	}).fail(function(){
+		// Ads.txt not found
+		$('.existing-adstxt').hide();
+	});
+
 	submit.on( 'click', function( e ){
 		e.preventDefault();
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -7,14 +7,19 @@
 			mode: 'shell'
 		} );
 
-	$('.ads-txt-rerun-check').click(function(){
+	function checkForAdsFile(){
 		$.get('/ads.txt', function( data, status ){
 			$('.existing-adstxt').show();
 		}).fail(function(){
 			// Ads.txt not found
 			$('.existing-adstxt').hide();
 		});
-	});
+	}
+	
+	// Call our check when we first load the page
+	checkForAdsFile();
+
+	$('.ads-txt-rerun-check').click( checkForAdsFile );
 
 	submit.on( 'click', function( e ){
 		e.preventDefault();


### PR DESCRIPTION
Addresses https://github.com/10up/ads-txt/issues/16

When the presence of an existing `ads.txt` is detected, display a notification on the edit screen.

<img width="1290" alt="screen shot 2018-02-22 at 3 09 28 pm" src="https://user-images.githubusercontent.com/2965444/36564326-7ab9e890-17e2-11e8-9fc6-ba7df8c6160d.png">
