### PR TITLE
Try using GH Actions for CI instead of Travis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Automated Tests
 
 on:
   pull_request:
@@ -9,6 +9,7 @@ on:
       - develop
 jobs:
   test_php:
+    name: Test PHP
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   test_php:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['5.6', '7.3']
     
     steps:
     - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - develop
+jobs:
+  test_php:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install dependencies
+      run: composer install
+    - name: Run PHPCS
+      run: composer run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,5 +16,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Install dependencies
       run: composer install
+    - name: PHP version
+      run: php --version
     - name: Run PHPCS
       run: composer run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - develop
+  push:
+    branches:
+      - develop
 jobs:
   test_php:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,14 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Install dependencies
-      run: composer install
+    - name: Set PHP version
+      uses: shivammathur/setup-php@v1
+      with:
+        php-version: ${{ matrix.php-versions }}
+        coverage: none
     - name: PHP version
       run: php --version
+    - name: Install dependencies
+      run: composer install --ignore-platform-reqs
     - name: Run PHPCS
       run: composer run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: php
-php:
-  - 7.2
-env:
-  - CMD="lint"
-install:
-  - "composer install"
-script:
-  - "composer $CMD"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Create, manage, and validate your Ads.txt from within WordPress, just like any other content asset.
 
-[![Build Status](https://travis-ci.org/10up/ads-txt.svg?branch=develop)](https://travis-ci.org/10up/ads-txt) [![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Release Version](https://img.shields.io/github/tag/10up/ads-txt.svg?label=release)](https://github.com/10up/ads-txt/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.3%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/ads-txt.svg)](https://github.com/10up/ads-txt/blob/develop/LICENSE.md)
+[![Build Status](https://img.shields.io/github/workflow/status/10up/ads-txt/test)](https://github.com/10up/ads-txt/actions?query=workflow%3ATest) [![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Release Version](https://img.shields.io/github/tag/10up/ads-txt.svg?label=release)](https://github.com/10up/ads-txt/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.3%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/ads-txt.svg)](https://github.com/10up/ads-txt/blob/develop/LICENSE.md)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Create, manage, and validate your Ads.txt from within WordPress, just like any other content asset.
 
-[![Build Status](https://img.shields.io/github/workflow/status/10up/ads-txt/Automated%20Tests)](https://github.com/10up/ads-txt/actions?query=workflow%3AAutomated%20Tests) [![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Release Version](https://img.shields.io/github/tag/10up/ads-txt.svg?label=release)](https://github.com/10up/ads-txt/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.3%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/ads-txt.svg)](https://github.com/10up/ads-txt/blob/develop/LICENSE.md)
+[![Automated Tests](https://github.com/10up/ads-txt/workflows/Automated%20Tests/badge.svg)](https://github.com/10up/ads-txt/actions?query=workflow%3A%22Automated+Tests%22) [![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Release Version](https://img.shields.io/github/tag/10up/ads-txt.svg?label=release)](https://github.com/10up/ads-txt/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.3%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/ads-txt.svg)](https://github.com/10up/ads-txt/blob/develop/LICENSE.md)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Create, manage, and validate your Ads.txt from within WordPress, just like any other content asset.
 
-[![Build Status](https://img.shields.io/github/workflow/status/10up/ads-txt/test)](https://github.com/10up/ads-txt/actions?query=workflow%3ATest) [![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Release Version](https://img.shields.io/github/tag/10up/ads-txt.svg?label=release)](https://github.com/10up/ads-txt/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.3%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/ads-txt.svg)](https://github.com/10up/ads-txt/blob/develop/LICENSE.md)
+[![Build Status](https://img.shields.io/github/workflow/status/10up/ads-txt/Automated%20Tests)](https://github.com/10up/ads-txt/actions?query=workflow%3AAutomated%20Tests) [![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Release Version](https://img.shields.io/github/tag/10up/ads-txt.svg?label=release)](https://github.com/10up/ads-txt/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.3%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/ads-txt.svg)](https://github.com/10up/ads-txt/blob/develop/LICENSE.md)
 
 ## Features
 


### PR DESCRIPTION
### Description of the Change

Adds a very barebones `test.yml` to run PHPCS in whatever the version of PHP is in the default Ubuntu image. I think that's currently 7.3 We may want to define the version or add a matrix eventually. If we merge this, we need to remove `.travis.yml` and unhook this from Travis.

### Alternate Designs

Sticking to Travis.

### Benefits

Travis has been quite slow and even getting stuck sometimes.

### Possible Drawbacks

Not aware of any.

### Verification Process

Don't have one, just gonna push and hope :)

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a sorry

### Changelog Entry

