### PR TITLE
Add app-ads.txt

### DIFF
--- a/ads-txt.php
+++ b/ads-txt.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'ADS_TXT_MANAGER_VERSION', '1.2.0' );
 define( 'ADS_TXT_MANAGE_CAPABILITY', 'edit_ads_txt' );
 define( 'ADS_TXT_MANAGER_POST_OPTION', 'adstxt_post' );
-define( 'APP_ADS_TXT_MANAGER_POST_OPTION', 'appadstxt_post' );
+define( 'APP_ADS_TXT_MANAGER_POST_OPTION', 'app_adstxt_post' );
 
 require_once __DIR__ . '/inc/post-type.php';
 require_once __DIR__ . '/inc/admin.php';
@@ -66,7 +66,7 @@ function tenup_display_ads_txt() {
 			 *
 			 * @param type  $app_adstxt The existing ads.txt content.
 			 */
-			echo esc_html( apply_filters( 'app_ads_txt_content', $app_adstxt ) );
+			echo esc_html( apply_filters( 'app_ads_txt_content', $adstxt ) );
 			die();
 		}
 	}

--- a/ads-txt.php
+++ b/ads-txt.php
@@ -18,6 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'ADS_TXT_MANAGER_VERSION', '1.2.0' );
 define( 'ADS_TXT_MANAGE_CAPABILITY', 'edit_ads_txt' );
 define( 'ADS_TXT_MANAGER_POST_OPTION', 'adstxt_post' );
+define( 'APP_ADS_TXT_MANAGER_POST_OPTION', 'appadstxt_post' );
 
 require_once __DIR__ . '/inc/post-type.php';
 require_once __DIR__ . '/inc/admin.php';
@@ -47,6 +48,25 @@ function tenup_display_ads_txt() {
 			 * @param type  $adstxt The existing ads.txt content.
 			 */
 			echo esc_html( apply_filters( 'ads_txt_content', $adstxt ) );
+			die();
+		}
+	} else if ( '/app-ads.txt' === $request ) {
+		$post_id = get_option( APP_ADS_TXT_MANAGER_POST_OPTION );
+
+		// Will fall through if no option found, likely to a 404.
+		if ( ! empty( $post_id ) ) {
+			$post = get_post( $post_id );
+			header( 'Content-Type: text/plain' );
+			$adstxt = $post->post_content;
+
+			/**
+			 * Filter the app-ads.txt content.
+			 *
+			 * @since 1.3.0
+			 *
+			 * @param type  $app_adstxt The existing ads.txt content.
+			 */
+			echo esc_html( apply_filters( 'app_ads_txt_content', $app_adstxt ) );
 			die();
 		}
 	}

--- a/ads-txt.php
+++ b/ads-txt.php
@@ -37,6 +37,11 @@ function tenup_display_ads_txt() {
 		// Will fall through if no option found, likely to a 404.
 		if ( ! empty( $post_id ) ) {
 			$post = get_post( $post_id );
+
+			if ( ! $post instanceof WP_Post ) {
+				return;
+			}
+
 			header( 'Content-Type: text/plain' );
 			$adstxt = $post->post_content;
 
@@ -56,6 +61,11 @@ function tenup_display_ads_txt() {
 		// Will fall through if no option found, likely to a 404.
 		if ( ! empty( $post_id ) ) {
 			$post = get_post( $post_id );
+
+			if ( ! $post instanceof WP_Post ) {
+				return;
+			}
+
 			header( 'Content-Type: text/plain' );
 			$adstxt = $post->post_content;
 

--- a/ads-txt.php
+++ b/ads-txt.php
@@ -50,7 +50,7 @@ function tenup_display_ads_txt() {
 			echo esc_html( apply_filters( 'ads_txt_content', $adstxt ) );
 			die();
 		}
-	} else if ( '/app-ads.txt' === $request ) {
+	} elseif ( '/app-ads.txt' === $request ) {
 		$post_id = get_option( APP_ADS_TXT_MANAGER_POST_OPTION );
 
 		// Will fall through if no option found, likely to a 404.

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -171,9 +171,14 @@ function admin_menu() {
 }
 add_action( 'admin_menu', __NAMESPACE__ . '\admin_menu' );
 
+/**
+ * Set up settings screen for ads.txt.
+ *
+ * @return void
+ */
 function adstxt_settings_screen() {
 	$post_id = get_option( ADS_TXT_MANAGER_POST_OPTION );
-	
+
 	$strings = array(
 		'existing'      => __( 'Existing Ads.txt file found', 'ads-txt' ),
 		'precedence'    => __( 'An ads.txt file on the server will take precedence over any content entered here. You will need to rename or remove the existing ads.txt file before you will be able to see any changes you make on this screen.', 'ads-txt' ),
@@ -192,9 +197,14 @@ function adstxt_settings_screen() {
 	settings_screen( $post_id, $strings, $args );
 }
 
+/**
+ * Set up settings screen for app-ads.txt.
+ *
+ * @return void
+ */
 function app_adstxt_settings_screen() {
 	$post_id = get_option( APP_ADS_TXT_MANAGER_POST_OPTION );
-	
+
 	$strings = array(
 		'existing'      => __( 'Existing App-ads.txt file found', 'ads-txt' ),
 		'precedence'    => __( 'An app-ads.txt file on the server will take precedence over any content entered here. You will need to rename or remove the existing app-ads.txt file before you will be able to see any changes you make on this screen.', 'ads-txt' ),
@@ -215,6 +225,10 @@ function app_adstxt_settings_screen() {
 
 /**
  * Output the settings screen for both files.
+ *
+ * @param int   $post_id Post ID associated with the file.
+ * @param array $strings Translated strings that mention the specific file name.
+ * @param array $args    Array of other necessary information to appropriately name items.
  *
  * @return void
  */
@@ -441,7 +455,7 @@ function get_error_messages() {
 function admin_notices() {
 	if ( 'settings_page_adstxt-settings' === get_current_screen()->base ) {
 		$saved = __( 'Ads.txt saved', 'ads-txt' );
-	} else if ( 'settings_page_app-adstxt-settings' === get_current_screen()->base ) {
+	} elseif ( 'settings_page_app-adstxt-settings' === get_current_screen()->base ) {
 		$saved = __( 'App-ads.txt saved', 'ads-txt' );
 	} else {
 		return;

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -15,7 +15,7 @@ namespace AdsTxt;
  * @return void
  */
 function admin_enqueue_scripts( $hook ) {
-	if ( 'settings_page_adstxt-settings' !== $hook ) {
+	if ( ! preg_match( '/adstxt-settings$/', $hook ) ) {
 		return;
 	}
 
@@ -38,6 +38,10 @@ function admin_enqueue_scripts( $hook ) {
 		'error_message' => esc_html__( 'Your Ads.txt contains the following issues:', 'ads-txt' ),
 		'unknown_error' => esc_html__( 'An unknown error occurred.', 'ads-txt' ),
 	);
+
+	if ( 'settings_page_app-adstxt-settings' === $hook ) {
+		$strings['error_message'] = esc_html__( 'Your app-ads.txt contains the following issues:', 'ads-txt' );
+	}
 
 	wp_localize_script( 'adstxt', 'adstxt', $strings );
 }
@@ -64,6 +68,7 @@ function admin_head_css() {
 	<?php
 }
 add_action( 'admin_head-settings_page_adstxt-settings', __NAMESPACE__ . '\admin_head_css' );
+add_action( 'admin_head-settings_page_app-adstxt-settings', __NAMESPACE__ . '\admin_head_css' );
 
 /**
  * Appends a query argument to the edit url to make sure it is redirected to
@@ -75,13 +80,19 @@ add_action( 'admin_head-settings_page_adstxt-settings', __NAMESPACE__ . '\admin_
  * @return string Edit url.
  */
 function ads_txt_adjust_revisions_return_to_editor_link( $url ) {
-	global $pagenow;
+	global $pagenow, $post;
 
 	if ( 'revision.php' !== $pagenow || ! isset( $_REQUEST['adstxt'] ) ) { // @codingStandardsIgnoreLine Nonce not required.
 		return $url;
 	}
 
-	return admin_url( 'options-general.php?page=adstxt-settings' );
+	$type = 'adstxt';
+
+	if ( 'appadstxt' === $post->post_type ) {
+		$type = 'app-adstxt';
+	}
+
+	return admin_url( 'options-general.php?page=' . $type . '-settings' );
 }
 add_filter( 'get_edit_post_link', __NAMESPACE__ . '\ads_txt_adjust_revisions_return_to_editor_link' );
 
@@ -147,18 +158,69 @@ function admin_menu() {
 		esc_html__( 'Ads.txt', 'ads-txt' ),
 		ADS_TXT_MANAGE_CAPABILITY,
 		'adstxt-settings',
-		__NAMESPACE__ . '\settings_screen'
+		__NAMESPACE__ . '\adstxt_settings_screen'
+	);
+
+	add_options_page(
+		esc_html__( 'App-ads.txt', 'ads-txt' ),
+		esc_html__( 'App-ads.txt', 'ads-txt' ),
+		ADS_TXT_MANAGE_CAPABILITY,
+		'app-adstxt-settings',
+		__NAMESPACE__ . '\app_adstxt_settings_screen'
 	);
 }
 add_action( 'admin_menu', __NAMESPACE__ . '\admin_menu' );
 
+function adstxt_settings_screen() {
+	$post_id = get_option( ADS_TXT_MANAGER_POST_OPTION );
+	
+	$strings = array(
+		'existing'      => __( 'Existing Ads.txt file found', 'ads-txt' ),
+		'precedence'    => __( 'An ads.txt file on the server will take precedence over any content entered here. You will need to rename or remove the existing ads.txt file before you will be able to see any changes you make on this screen.', 'ads-txt' ),
+		'errors'        => __( 'Your Ads.txt contains the following issues:', 'ads-txt' ),
+		'screen_title'  => __( 'Manage Ads.txt', 'ads-txt' ),
+		'content_label' => __( 'Ads.txt content', 'ads-txt' ),
+	);
+
+	$args = array(
+		'post_type'  => 'adstxt',
+		'post_title' => 'Ads.txt',
+		'option'     => ADS_TXT_MANAGER_POST_OPTION,
+		'action'     => 'adstxt-save',
+		'nonce_name' => 'adstxt_save'
+	);
+
+	settings_screen( $post_id, $strings, $args );
+}
+
+function app_adstxt_settings_screen() {
+	$post_id = get_option( APP_ADS_TXT_MANAGER_POST_OPTION );
+	
+	$strings = array(
+		'existing'      => __( 'Existing App-ads.txt file found', 'ads-txt' ),
+		'precedence'    => __( 'An app-ads.txt file on the server will take precedence over any content entered here. You will need to rename or remove the existing app-ads.txt file before you will be able to see any changes you make on this screen.', 'ads-txt' ),
+		'errors'        => __( 'Your app-ads.txt contains the following issues:', 'ads-txt' ),
+		'screen_title'  => __( 'Manage App-ads.txt', 'ads-txt' ),
+		'content_label' => __( 'App-ads.txt content', 'ads-txt' ),
+	);
+
+	$args = array(
+		'post_type'  => 'appadstxt',
+		'post_title' => 'App-ads.txt',
+		'option'     => APP_ADS_TXT_MANAGER_POST_OPTION,
+		'action'     => 'appadstxt-save',
+		'nonce_name' => 'appadstxt_save'
+	);
+
+	settings_screen( $post_id, $strings, $args );
+}
+
 /**
- * Output the settings screen.
+ * Output the settings screen for both files.
  *
  * @return void
  */
-function settings_screen() {
-	$post_id          = get_option( ADS_TXT_MANAGER_POST_OPTION );
+function settings_screen( $post_id, $strings, $args ) {
 	$post             = false;
 	$content          = false;
 	$errors           = [];
@@ -182,29 +244,29 @@ function settings_screen() {
 
 		// Create an initial post so the second save creates a comparable revision.
 		$postarr = array(
-			'post_title'   => 'Ads.txt',
+			'post_title'   => $args['post_title'],
 			'post_content' => '',
-			'post_type'    => 'adstxt',
+			'post_type'    => $args['post_type'],
 			'post_status'  => 'publish',
 		);
 
 		$post_id = wp_insert_post( $postarr );
 		if ( $post_id ) {
-			update_option( ADS_TXT_MANAGER_POST_OPTION, $post_id );
+			update_option( $args['option'], $post_id );
 		}
 	}
 	?>
 <div class="wrap">
 	<div class="notice notice-error adstxt-notice existing-adstxt" style="display: none;">
-		<p><strong><?php echo esc_html_e( 'Existing Ads.txt file found', 'ads-txt' ); ?></strong></p>
-		<p><?php echo esc_html_e( 'An ads.txt file on the server will take precedence over any content entered here. You will need to rename or remove the existing ads.txt file before you will be able to see any changes you make on this screen.', 'ads-txt' ); ?></p>
+		<p><strong><?php echo esc_html( $strings['existing'] ); ?></strong></p>
+		<p><?php echo esc_html( $strings['precedence'] ); ?></p>
 
 		<p><?php echo esc_html_e( 'Removed the existing file but are still seeing this warning?', 'ads-txt' ); ?> <a class="ads-txt-rerun-check" href="#"><?php echo esc_html_e( 'Re-run the check now', 'ads-txt' ); ?></a> <span class="spinner" style="float:none;margin:-2px 5px 0"></span></p>
 	</div>
 
 	<?php if ( ! empty( $errors ) ) : ?>
 	<div class="notice notice-error adstxt-notice">
-		<p><strong><?php echo esc_html__( 'Your Ads.txt contains the following issues:', 'ads-txt' ); ?></strong></p>
+		<p><strong><?php echo esc_html( $strings['errors'] ); ?></strong></p>
 		<ul>
 			<?php
 			foreach ( $errors as $error ) {
@@ -232,14 +294,14 @@ function settings_screen() {
 	</div>
 	<?php endif; ?>
 
-	<h2><?php echo esc_html__( 'Manage Ads.txt', 'ads-txt' ); ?></h2>
+	<h2><?php echo esc_html( $strings['screen_title'] ); ?></h2>
 
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="adstxt-settings-form">
 		<input type="hidden" name="post_id" value="<?php echo esc_attr( $post_id ) ? esc_attr( $post_id ) : ''; ?>" />
-		<input type="hidden" name="action" value="adstxt-save" />
-		<?php wp_nonce_field( 'adstxt_save' ); ?>
+		<input type="hidden" name="action" value="<?php echo esc_attr( $args['action'] ); ?>" />
+		<?php wp_nonce_field( $args['nonce_name'] ); ?>
 
-		<label class="screen-reader-text" for="adstxt_content"><?php echo esc_html__( 'Ads.txt content', 'ads-txt' ); ?></label>
+		<label class="screen-reader-text" for="adstxt_content"><?php echo esc_html( $strings['content_label'] ); ?></label>
 		<textarea class="widefat code" rows="25" name="adstxt" id="adstxt_content"><?php echo esc_textarea( $content ); ?></textarea>
 		<?php
 		if ( $revision_count > 1 ) {
@@ -378,14 +440,18 @@ function get_error_messages() {
  * @return void
  */
 function admin_notices() {
-	if ( 'settings_page_adstxt-settings' !== get_current_screen()->base ) {
+	if ( 'settings_page_adstxt-settings' === get_current_screen()->base ) {
+		$saved = __( 'Ads.txt saved', 'ads-txt' );
+	} else if ( 'settings_page_app-adstxt-settings' === get_current_screen()->base ) {
+		$saved = __( 'App-ads.txt saved', 'ads-txt' );
+	} else {
 		return;
 	}
 
 	if ( isset( $_GET['ads_txt_saved'] ) ) : // @codingStandardsIgnoreLine Nonce not required.
 		?>
 	<div class="notice notice-success adstxt-notice adstxt-saved">
-		<p><?php echo esc_html__( 'Ads.txt saved', 'ads-txt' ); ?></p>
+		<p><?php echo esc_html( $saved ); ?></p>
 	</div>
 		<?php
 	elseif ( isset( $_GET['revision'] ) ) : // @codingStandardsIgnoreLine Nonce not required.

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -88,7 +88,7 @@ function ads_txt_adjust_revisions_return_to_editor_link( $url ) {
 
 	$type = 'adstxt';
 
-	if ( 'appadstxt' === $post->post_type ) {
+	if ( 'app-adstxt' === $post->post_type ) {
 		$type = 'app-adstxt';
 	}
 
@@ -187,7 +187,6 @@ function adstxt_settings_screen() {
 		'post_title' => 'Ads.txt',
 		'option'     => ADS_TXT_MANAGER_POST_OPTION,
 		'action'     => 'adstxt-save',
-		'nonce_name' => 'adstxt_save'
 	);
 
 	settings_screen( $post_id, $strings, $args );
@@ -205,11 +204,10 @@ function app_adstxt_settings_screen() {
 	);
 
 	$args = array(
-		'post_type'  => 'appadstxt',
+		'post_type'  => 'app-adstxt',
 		'post_title' => 'App-ads.txt',
 		'option'     => APP_ADS_TXT_MANAGER_POST_OPTION,
-		'action'     => 'appadstxt-save',
-		'nonce_name' => 'appadstxt_save'
+		'action'     => 'app-adstxt-save',
 	);
 
 	settings_screen( $post_id, $strings, $args );
@@ -298,8 +296,9 @@ function settings_screen( $post_id, $strings, $args ) {
 
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="adstxt-settings-form">
 		<input type="hidden" name="post_id" value="<?php echo esc_attr( $post_id ) ? esc_attr( $post_id ) : ''; ?>" />
+		<input type="hidden" name="adstxt_type" value="<?php echo esc_attr( $args['post_type'] ); ?>" />
 		<input type="hidden" name="action" value="<?php echo esc_attr( $args['action'] ); ?>" />
-		<?php wp_nonce_field( $args['nonce_name'] ); ?>
+		<?php wp_nonce_field( 'adstxt_save' ); ?>
 
 		<label class="screen-reader-text" for="adstxt_content"><?php echo esc_html( $strings['content_label'] ); ?></label>
 		<textarea class="widefat code" rows="25" name="adstxt" id="adstxt_content"><?php echo esc_textarea( $content ); ?></textarea>

--- a/inc/post-type.php
+++ b/inc/post-type.php
@@ -13,38 +13,51 @@ namespace Adstxt;
  * @return void
  */
 function register() {
+	$args = array(
+		'public'           => false,
+		'hierarchical'     => false,
+		'rewrite'          => false,
+		'query_var'        => false,
+		'delete_with_user' => false,
+		'supports'         => array( 'revisions' ),
+		'map_meta_cap'     => true,
+		'capabilities'     => array(
+			'create_posts'           => 'customize',
+			'delete_others_posts'    => 'customize',
+			'delete_post'            => 'customize',
+			'delete_posts'           => 'customize',
+			'delete_private_posts'   => 'customize',
+			'delete_published_posts' => 'customize',
+			'edit_others_posts'      => 'customize',
+			'edit_post'              => 'customize',
+			'edit_posts'             => 'customize',
+			'edit_private_posts'     => 'customize',
+			'edit_published_posts'   => 'edit_published_posts',
+			'publish_posts'          => 'customize',
+			'read'                   => 'read',
+			'read_post'              => 'customize',
+			'read_private_posts'     => 'customize',
+		),
+	);
+
 	register_post_type(
-		'adstxt',
+		'adstxt', array_merge(
 		array(
 			'labels'           => array(
 				'name'          => esc_html_x( 'Ads.txt', 'post type general name', 'ads-txt' ),
 				'singular_name' => esc_html_x( 'Ads.txt', 'post type singular name', 'ads-txt' ),
 			),
-			'public'           => false,
-			'hierarchical'     => false,
-			'rewrite'          => false,
-			'query_var'        => false,
-			'delete_with_user' => false,
-			'supports'         => array( 'revisions' ),
-			'map_meta_cap'     => true,
-			'capabilities'     => array(
-				'create_posts'           => 'customize',
-				'delete_others_posts'    => 'customize',
-				'delete_post'            => 'customize',
-				'delete_posts'           => 'customize',
-				'delete_private_posts'   => 'customize',
-				'delete_published_posts' => 'customize',
-				'edit_others_posts'      => 'customize',
-				'edit_post'              => 'customize',
-				'edit_posts'             => 'customize',
-				'edit_private_posts'     => 'customize',
-				'edit_published_posts'   => 'edit_published_posts',
-				'publish_posts'          => 'customize',
-				'read'                   => 'read',
-				'read_post'              => 'customize',
-				'read_private_posts'     => 'customize',
+		), $args )
+	);
+
+	register_post_type(
+		'appadstxt', array_merge(
+		array(
+			'labels'           => array(
+				'name'          => esc_html_x( 'App-ads.txt', 'post type general name', 'ads-txt' ),
+				'singular_name' => esc_html_x( 'App-ads.txt', 'post type singular name', 'ads-txt' ),
 			),
-		)
+		), $args )
 	);
 }
 

--- a/inc/post-type.php
+++ b/inc/post-type.php
@@ -51,7 +51,7 @@ function register() {
 	);
 
 	register_post_type(
-		'appadstxt', array_merge(
+		'app-adstxt', array_merge(
 		array(
 			'labels'           => array(
 				'name'          => esc_html_x( 'App-ads.txt', 'post type general name', 'ads-txt' ),

--- a/inc/post-type.php
+++ b/inc/post-type.php
@@ -41,23 +41,29 @@ function register() {
 	);
 
 	register_post_type(
-		'adstxt', array_merge(
-		array(
-			'labels'           => array(
-				'name'          => esc_html_x( 'Ads.txt', 'post type general name', 'ads-txt' ),
-				'singular_name' => esc_html_x( 'Ads.txt', 'post type singular name', 'ads-txt' ),
+		'adstxt',
+		array_merge(
+			array(
+				'labels' => array(
+					'name'          => esc_html_x( 'Ads.txt', 'post type general name', 'ads-txt' ),
+					'singular_name' => esc_html_x( 'Ads.txt', 'post type singular name', 'ads-txt' ),
+				),
 			),
-		), $args )
+			$args
+		)
 	);
 
 	register_post_type(
-		'app-adstxt', array_merge(
-		array(
-			'labels'           => array(
-				'name'          => esc_html_x( 'App-ads.txt', 'post type general name', 'ads-txt' ),
-				'singular_name' => esc_html_x( 'App-ads.txt', 'post type singular name', 'ads-txt' ),
+		'app-adstxt',
+		array_merge(
+			array(
+				'labels' => array(
+					'name'          => esc_html_x( 'App-ads.txt', 'post type general name', 'ads-txt' ),
+					'singular_name' => esc_html_x( 'App-ads.txt', 'post type singular name', 'ads-txt' ),
+				),
 			),
-		), $args )
+			$args
+		)
 	);
 }
 

--- a/inc/save.php
+++ b/inc/save.php
@@ -41,7 +41,7 @@ function save() {
 	}
 
 	$sanitized = implode( PHP_EOL, $sanitized );
-	$postarr = array(
+	$postarr   = array(
 		'ID'           => $post_id,
 		'post_title'   => 'Ads.txt',
 		'post_content' => $sanitized,
@@ -54,7 +54,7 @@ function save() {
 
 	if ( 'app-adstxt' === $_post['adstxt_type'] ) {
 		$postarr['post_title'] = 'App-ads.txt';
-		$postarr['post_type'] = 'app-adstxt';
+		$postarr['post_type']  = 'app-adstxt';
 	}
 
 	if ( ! $doing_ajax || empty( $errors ) || 'y' === $ays ) {

--- a/inc/save.php
+++ b/inc/save.php
@@ -42,16 +42,29 @@ function save() {
 
 	$sanitized = implode( PHP_EOL, $sanitized );
 
-	$postarr = array(
-		'ID'           => $post_id,
-		'post_title'   => 'Ads.txt',
-		'post_content' => $sanitized,
-		'post_type'    => 'adstxt',
-		'post_status'  => 'publish',
-		'meta_input'   => array(
-			'adstxt_errors' => $errors,
-		),
-	);
+	if ( 'app-adstxt' === $_post['adstxt_type'] ) {
+		$postarr = array(
+			'ID'           => $post_id,
+			'post_title'   => 'App-ads.txt',
+			'post_content' => $sanitized,
+			'post_type'    => 'app-adstxt',
+			'post_status'  => 'publish',
+			'meta_input'   => array(
+				'adstxt_errors' => $errors,
+			),
+		);
+	} else {
+		$postarr = array(
+			'ID'           => $post_id,
+			'post_title'   => 'Ads.txt',
+			'post_content' => $sanitized,
+			'post_type'    => 'adstxt',
+			'post_status'  => 'publish',
+			'meta_input'   => array(
+				'adstxt_errors' => $errors,
+			),
+		);
+	}
 
 	if ( ! $doing_ajax || empty( $errors ) || 'y' === $ays ) {
 		$post_id = wp_insert_post( $postarr );
@@ -76,7 +89,9 @@ function save() {
 	exit;
 }
 add_action( 'admin_post_adstxt-save', __NAMESPACE__ . '\save' );
+add_action( 'admin_post_app-adstxt-save', __NAMESPACE__ . '\save' );
 add_action( 'wp_ajax_adstxt-save', __NAMESPACE__ . '\save' );
+add_action( 'wp_ajax_app-adstxt-save', __NAMESPACE__ . '\save' );
 
 /**
  * Validate a single line.

--- a/inc/save.php
+++ b/inc/save.php
@@ -41,29 +41,20 @@ function save() {
 	}
 
 	$sanitized = implode( PHP_EOL, $sanitized );
+	$postarr = array(
+		'ID'           => $post_id,
+		'post_title'   => 'Ads.txt',
+		'post_content' => $sanitized,
+		'post_type'    => 'adstxt',
+		'post_status'  => 'publish',
+		'meta_input'   => array(
+			'adstxt_errors' => $errors,
+		),
+	);
 
 	if ( 'app-adstxt' === $_post['adstxt_type'] ) {
-		$postarr = array(
-			'ID'           => $post_id,
-			'post_title'   => 'App-ads.txt',
-			'post_content' => $sanitized,
-			'post_type'    => 'app-adstxt',
-			'post_status'  => 'publish',
-			'meta_input'   => array(
-				'adstxt_errors' => $errors,
-			),
-		);
-	} else {
-		$postarr = array(
-			'ID'           => $post_id,
-			'post_title'   => 'Ads.txt',
-			'post_content' => $sanitized,
-			'post_type'    => 'adstxt',
-			'post_status'  => 'publish',
-			'meta_input'   => array(
-				'adstxt_errors' => $errors,
-			),
-		);
+		$postarr['post_title'] = 'App-ads.txt';
+		$postarr['post_type'] = 'app-adstxt';
 	}
 
 	if ( ! $doing_ajax || empty( $errors ) || 'y' === $ays ) {


### PR DESCRIPTION
### Description of the Change

Adds another settings screen to create/edit an `app-ads.txt`.

### Alternate Designs

n/a

### Benefits

Adds a feature that is seeing more requests from major users.

### Possible Drawbacks

Additional settings submenu item that people may not need.

### Verification Process

* Ensured the initial revision and option save happened on first screen load
* Added content and checked for error message return
* Checked for domain.com/app-ads.txt appearing as expected
* Changed content and checked revisions and return link
* Restored a revision and ensured it worked as expected

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Fixes #40 

### Changelog Entry

Still needs to be done.
