### PR TITLE
add app-ads.txt tag to readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: 10up, helen, adamsilverstein, jakemgold
 Author URI: https://10up.com
 Plugin URI: https://github.com/10up/ads-txt
-Tags: ads.txt, ads, ad manager, advertising, publishing, publishers
+Tags: ads.txt, app-ads.txt, ads, ad manager, advertising, publishing, publishers
 Requires at least: 4.9
 Tested up to: 5.4
 Requires PHP: 5.3


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

In pulling a screenshot of the new app-ads.txt functionality I realized that we don't have `app-ads.txt` as a tag on dotorg.  This PR adds the tag to the readme.txt file so it appears on dotorg.

### Alternate Designs

Keep as-is.

### Benefits

I'm not sure how much the tags go into dotorg and WP Admin search results, but theoretically this should help ensure the plugin appears when folks search for app-ads.txt?

### Possible Drawbacks

none identified.

### Verification Process

Manually verified via the GitHub web UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
n/a