### PR TITLE
Update edit_others_posts to allow all admins to access revisions.

### DIFF
--- a/inc/post-type.php
+++ b/inc/post-type.php
@@ -28,7 +28,7 @@ function register() {
 			'delete_posts'           => 'customize',
 			'delete_private_posts'   => 'customize',
 			'delete_published_posts' => 'customize',
-			'edit_others_posts'      => 'customize',
+			'edit_others_posts'      => 'edit_others_posts',
 			'edit_post'              => 'customize',
 			'edit_posts'             => 'customize',
 			'edit_private_posts'     => 'customize',


### PR DESCRIPTION
Use edit_others_posts to allow all admins to access revisions.

<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Resolves the issue described here: https://github.com/10up/ads-txt/issues/67 by adding a capability name to edit_others_posts.

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs
We could create a custom permission or use `ADS_TXT_MANAGE_CAPABILITY` instead of edit_others_posts..
<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
I have tested this locally and it resolves the issue.
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues
https://github.com/10up/ads-txt/issues/67
<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
