### PR TITLE
Add `INVENTORYPARTNERDOMAIN` as a supported variable

### DIFF
--- a/inc/save.php
+++ b/inc/save.php
@@ -104,7 +104,7 @@ function validate_line( $line, $line_number ) {
 	} elseif ( 0 === strpos( $line, '#' ) ) { // This is a full-line comment.
 		$sanitized = wp_strip_all_tags( $line );
 	} elseif ( 1 < strpos( $line, '=' ) ) { // This is a variable declaration.
-		// The spec currently supports CONTACT and SUBDOMAIN.
+		// The spec currently supports CONTACT, INVENTORYPARTNERDOMAIN and SUBDOMAIN.
 		if ( ! preg_match( '/^(CONTACT|SUBDOMAIN|INVENTORYPARTNERDOMAIN)=/i', $line ) ) {
 			$errors[] = array(
 				'line' => $line_number,

--- a/inc/save.php
+++ b/inc/save.php
@@ -105,7 +105,7 @@ function validate_line( $line, $line_number ) {
 		$sanitized = wp_strip_all_tags( $line );
 	} elseif ( 1 < strpos( $line, '=' ) ) { // This is a variable declaration.
 		// The spec currently supports CONTACT and SUBDOMAIN.
-		if ( ! preg_match( '/^(CONTACT|SUBDOMAIN)=/i', $line ) ) {
+		if ( ! preg_match( '/^(CONTACT|SUBDOMAIN|INVENTORYPARTNERDOMAIN)=/i', $line ) ) {
 			$errors[] = array(
 				'line' => $line_number,
 				'type' => 'invalid_variable',


### PR DESCRIPTION
### Description of the Change

In v1.0.3 of the ads.txt spec, a new variable called `INVENTORYPARTNERDOMAIN` was added. This PR adds that to our list of supported variables so you don't get a warning when saving.

### Alternate Designs

None

### Benefits

You won't get a warning on a valid variable

### Possible Drawbacks

None

### Verification Process

Create a ads.txt file with the following line:
`inventorypartnerdomain=test.com`

Ensure it saves properly with no errors and shows up properly in the actual ads.txt file

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

#72 

### Changelog Entry

> Added - support the INVENTORYPARTNERDOMAIN variable 