### PR TITLE
Run Cypress tests in WordPress environment rather than 'latest'

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - develop
-  push:
-    branches:
-      - test/wp-env-version
 jobs:
   cypress:
     name: E2E Tests

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -13,7 +13,7 @@ jobs:
         core:
           - {name: 'WP latest', version: 'latest'}
           - {name: 'WP minimum', version: 'WordPress/WordPress#4.9'}
-          - {name: 'WP nighty', version: 'WordPress/WordPress#master'}
+          - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - develop
+  push:
+    branches:
+      - test/wp-env-version
 jobs:
   cypress:
     name: E2E Tests
@@ -12,6 +15,8 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#4.9'}
+          - {name: 'WP nighty', version: 'WordPress/WordPress#master'}
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/tests/bin/initialize.sh
+++ b/tests/bin/initialize.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+npm run wp-env run tests-wordpress "chmod -c ugo+w /var/www/html"
 npm run wp-env run tests-cli "wp rewrite structure '/%postname%/' --hard"


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

<!-- Enter any applicable Issues here. Example: -->
In addition to #82, this PR fixes write permissions which made using permalinks impossible before. Allows to specify any custom WordPress version rather than default (latest).

### Alternate Designs

This also could be fixed with `chown www-data:www-data /var/www/html` but it will cause issues with `wp-env destroy` — require manual run of `sudo rm` command to delete the folder.

### Verification Process

Expected to run both 3 Cypress tests successfully on GitHub Actions: latest, minimum and nightly.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

n/a
### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @cadic
