### PR TITLE
Minimum WP and PHP version bumped to 5.7 and 7.4

### DIFF
--- a/.github/workflows/php8-compatibility.yml
+++ b/.github/workflows/php8-compatibility.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '5.3', '5.4', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        php: [ '7.4', '8.0', '8.1' ]
 
     steps:
     - name: Checkout

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#4.9'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#5.7'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
     steps:
     - name: Checkout

--- a/ads-txt.php
+++ b/ads-txt.php
@@ -1,12 +1,14 @@
 <?php
 /**
- * Plugin Name: Ads.txt Manager
- * Description: Create, manage, and validate your Ads.txt from within WordPress, just like any other content asset. Requires PHP 5.3+ and WordPress 4.9+.
- * Version:     1.4.0
- * Author:      10up
- * Author URI:  https://10up.com
- * License:     GPLv2 or later
- * Text Domain: ads-txt
+ * Plugin Name:       Ads.txt Manager
+ * Description:       Create, manage, and validate your Ads.txt from within WordPress, just like any other content asset. Requires PHP 5.3+ and WordPress 4.9+.
+ * Version:           1.4.0
+ * Author:            10up
+ * Author URI:        https://10up.com
+ * License:           GPLv2 or later
+ * Requires at least: 5.7
+ * Requires PHP:      7.4
+ * Text Domain:       ads-txt
  *
  * @package Ads_Txt_Manager
  */

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors:      10up, helen, adamsilverstein, jakemgold, peterwilsoncc
 Author URI:        https://10up.com
 Plugin URI:        https://github.com/10up/ads-txt
 Tags:              ads.txt, app-ads.txt, ads, ad manager, advertising, publishing, publishers
-Requires at least: 4.9
+Requires at least: 5.7
 Tested up to:      6.0
-Requires PHP:      5.3
+Requires PHP:      7.4
 Stable tag:        1.4.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/old-licenses/gpl-2.0.html


### PR DESCRIPTION
### Description of the Change
Minimum WP and PHP version requirement bumped to 5.7 and 7.4 respectively. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #102 

### How to test the Change
There's really nothing to test as only the minimum required version bumped. No functional change was necessary for it.

### Changelog Entry
> Minimum WP and PHP version requirement bumped to 5.7 and 7.4 respectively. 