### PR TITLE
Set Cypress base URL to a fully qualified URL.

### DIFF
--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -25,7 +25,7 @@ module.exports = async ( on, config ) => {
 		const port = wpEnvConfig.env.tests.port || null;
 
 		if ( port ) {
-			config.baseUrl = wpEnvConfig.env.tests.config.WP_TESTS_DOMAIN;
+			config.baseUrl = wpEnvConfig.env.tests.config.WP_SITEURL;
 		}
 	}
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #111 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Passing E2E tests on this pull request indicate success. See earlier [action failures](https://github.com/10up/ads-txt/actions/runs/3511512033).

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Base URL corrected for E2E test suite.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc, @cadic, @dkotter  


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
