### PR TITLE
WP tested up to 6.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Author URI:        https://10up.com
 Plugin URI:        https://github.com/10up/ads-txt
 Tags:              ads.txt, app-ads.txt, ads, ad manager, advertising, publishing, publishers
 Requires at least: 5.7
-Tested up to:      6.0
+Tested up to:      6.1
 Requires PHP:      7.4
 Stable tag:        1.4.0
 License:           GPLv2 or later


### PR DESCRIPTION
### Description of the Change
Resolved the issue `Warning: This plugin has not been tested with your current version of WordPress.` by increasing tested WP version to `6.1`

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #110 

### Changelog Entry

> Changed - Bump Wordpress tested up to to 6.1
