### PR TITLE
upkeep/106: remove matrix from PHP8 Compatibility check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.phpcs.xml.dist export-ignore
+/.phpcompat.xml.dist export-ignore
 /.phpunit.result.cache export-ignore
 /.wp-env.json export-ignore
 /.wp-env.override.json export-ignore

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -28,4 +28,4 @@ jobs:
       run: composer install
 
     - name: Lint PHP
-      run: ./vendor/bin/phpcs -p
+      run: ./vendor/bin/phpcs -p --standard=.phpcs.xml.dist

--- a/.github/workflows/php8-compatibility.yml
+++ b/.github/workflows/php8-compatibility.yml
@@ -15,13 +15,8 @@ on:
 
 jobs:
   php_compatibility:
-    name: PHP ${{ matrix.php }}
+    name: PHP minimum 7.4
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php: [ '7.4', '8.0', '8.1' ]
-
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -43,10 +38,10 @@ jobs:
       with:
         php-version: '7.4'
         coverage: none
-        tools: prestissimo, composer:v2
+        tools: composer:v2
 
     - name: Install dependencies
       run: composer install
 
     - name: Check PHP Compatibility
-      run: ./vendor/bin/phpcs -p ads-txt.php inc --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion ${{ matrix.php }}
+      run: ./vendor/bin/phpcs --standard=.phpcompat.xml.dist

--- a/.phpcompat.xml.dist
+++ b/.phpcompat.xml.dist
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset name="Ads.txt PHP Compatibility sniff">
+	<rule ref="PHPCompatibilityWP" />
+	<file>.</file>
+	<exclude-pattern>release/</exclude-pattern>
+	<exclude-pattern>vendor/</exclude-pattern>
+	<exclude-pattern>tests/</exclude-pattern>
+	<config name="testVersion" value="7.4-"/>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,12 +9,12 @@
 	verbose="true"
 >
 	<testsuites>
-		<testsuite name="Simple Podcasting">
+		<testsuite name="Ads.txt">
 			<directory prefix="test-" suffix=".php">./tests/unit</directory>
 		</testsuite>
 	</testsuites>
-    <php>
-        <ini name="display_errors" value="On" />
-        <ini name="display_startup_errors" value="On" />
-    </php>
+	<php>
+		<ini name="display_errors" value="On" />
+		<ini name="display_startup_errors" value="On" />
+	</php>
 </phpunit>


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Removes PHP matrix from PHP8 Compatibility action.

Closes #106 

### Changelog Entry

> Fixed - Removes PHP matrix from PHP8 Compatibility action.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc @Sidsector9 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
