### PR TITLE
Display PHP version names in unit test workflow.

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         php:
           - {name: 'PHP 7.4', version: '7.4'}
+          - {name: 'PHP 8.0', version: '8.0'}
           - {name: 'PHP 8.1', version: '8.1'}
 
     steps:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   phpunit:
-    name: ${{ matrix.name }}
+    name: ${{ matrix.php.name }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -49,6 +49,6 @@ jobs:
 
     - name: Install dependencies
       run: composer install
-    
+
     - name: Test
       run: ./vendor/bin/phpunit -v


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Corrects the reference in the `name` section of the unit tests to differentiate between PHP versions.

Restores the PHP Unit tests for PHP 8.0 as they are listed as required in the repos config.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #132

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

* Go to checks tab of this pull request
* Expand the Unit Tests section
* The list should show two runs: `PHP 7.4`, `PHP 8.0` and `PHP 8.1` (on develop these both show as `phpunit`).

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Corrected names for PHP Unit test suite runs.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc, @jeffpaul.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
