### PR TITLE
Bumed up tested upt o version to 6.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Author URI:        https://10up.com
 Plugin URI:        https://github.com/10up/ads-txt
 Tags:              ads.txt, app-ads.txt, ads, ad manager, advertising, publishing, publishers
 Requires at least: 5.7
-Tested up to:      6.2
+Tested up to:      6.3
 Requires PHP:      7.4
 Stable tag:        1.4.3
 License:           GPLv2 or later


### PR DESCRIPTION
### Description of the Change
Bumped up Tested up to version to 6.3
Closes #150 

### Changelog Entry
> Changed - Bumped WordPress "tested up to" version 6.3.


### Credits
Props @zamanq @jeffpaul 


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
