### PR TITLE
Bump WordPress "tested up to" version 6.4 on `trunk`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Author URI:        https://10up.com
 Plugin URI:        https://github.com/10up/ads-txt
 Tags:              ads.txt, app-ads.txt, ads, ad manager, advertising, publishing, publishers
 Requires at least: 5.7
-Tested up to:      6.3
+Tested up to:      6.4
 Requires PHP:      7.4
 Stable tag:        1.4.3
 License:           GPLv2 or later


### PR DESCRIPTION
Ports #156 to `trunk` to hopefully trigger the Readme action and push the update to WP.org.