### PR TITLE
Replace dirname( __FILE__ ) calls with __DIR__ magic constant

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -21,7 +21,7 @@ function admin_enqueue_scripts( $hook ) {
 
 	wp_enqueue_script(
 		'adstxt',
-		esc_url( plugins_url( '/js/admin.js', dirname( __FILE__ ) ) ),
+		esc_url( plugins_url( '/js/admin.js', __DIR__ ) ),
 		array( 'jquery', 'wp-backbone', 'wp-codemirror' ),
 		ADS_TXT_MANAGER_VERSION,
 		true
@@ -29,7 +29,7 @@ function admin_enqueue_scripts( $hook ) {
 	wp_enqueue_style( 'code-editor' );
 	wp_enqueue_style(
 		'adstxt',
-		esc_url( plugins_url( '/css/admin.css', dirname( __FILE__ ) ) ),
+		esc_url( plugins_url( '/css/admin.css', __DIR__ ) ),
 		array(),
 		ADS_TXT_MANAGER_VERSION
 	);


### PR DESCRIPTION
### Description of the Change
PHP 5.3 introduced the magic constant `__DIR__` which is equivalent to `dirname( __FILE__ )` and more efficient to use.

### Changelog Entry
> Developer - Replace `dirname( __FILE__ )` calls with `__DIR__` magic constant.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @Soean

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
