### PR TITLE
Add types to `apply_filters()` docs

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -36,7 +36,7 @@ function display_ads_txt() {
 			 *
 			 * @since 1.2.0
 			 *
-			 * @param type  $adstxt The existing ads.txt content.
+			 * @param string $adstxt The existing ads.txt content.
 			 */
 			echo esc_html( apply_filters( 'ads_txt_content', $adstxt ) );
 			die();
@@ -63,7 +63,7 @@ function display_ads_txt() {
 			 *
 			 * @since 1.3.0
 			 *
-			 * @param type  $app_adstxt The existing ads.txt content.
+			 * @param string $app_adstxt The existing ads.txt content.
 			 */
 			echo esc_html( apply_filters( 'app_ads_txt_content', $adstxt ) );
 			die();


### PR DESCRIPTION
### Description of the Change
Adds type `string` to `apply_filters( 'ads_txt_content' )` and `apply_filters( 'app_ads_txt_content' )` docs.

### Changelog Entry
> Developer - Improve `apply_filters()` documentation.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @Soean 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
