### PR TITLE
Early return condition in clean_orphaned_posts to prevent unnecessary processing

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -523,18 +523,16 @@ function clean_orphaned_posts( $option, $post_type ) {
 
 	$ads_posts = get_posts( $args );
 
+	// Remove the active post ID from the array.
+	$ads_posts = array_filter(
+		$ads_posts,
+		function ( $ads_post ) use ( $option ) {
+			return $ads_post !== (int) $option;
+		}
+	);
+
 	if ( empty( $ads_posts ) ) {
 		return false;
-	}
-
-	if ( 1 === count( $ads_posts ) && [ (int) $option ] === $ads_posts ) {
-		return false;
-	}
-
-	// Search for the active post ID and remove it from the array.
-	$index = array_search( (int) $option, $ads_posts, true );
-	if ( false !== $index ) {
-		unset( $ads_posts[ $index ] );
 	}
 
 	foreach ( $ads_posts as $post_id ) {

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -523,6 +523,10 @@ function clean_orphaned_posts( $option, $post_type ) {
 
 	$ads_posts = get_posts( $args );
 
+	if ( empty( $ads_posts ) ) {
+		return false;
+	}
+
 	if ( 1 === count( $ads_posts ) && [ (int) $option ] === $ads_posts ) {
 		return false;
 	}
@@ -531,10 +535,6 @@ function clean_orphaned_posts( $option, $post_type ) {
 	$index = array_search( (int) $option, $ads_posts, true );
 	if ( false !== $index ) {
 		unset( $ads_posts[ $index ] );
-	}
-
-	if ( empty( $ads_posts ) ) {
-		return false;
 	}
 
 	foreach ( $ads_posts as $post_id ) {


### PR DESCRIPTION
This update adjusts the logic in the `clean_orphaned_posts()` function to improve performance and avoid unnecessary execution when there are no posts to clean.

- Moved the `empty( $ads_posts )` check immediately after fetching posts to allow for an earlier return.
- Removed the redundant `empty( $ads_posts )` check after unsetting the `$option` from the array.