### PR TITLE
Bump WordPress "tested up to" version 6.8

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.5'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.6'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Yes! However, if you are using a subfolder installation it will only work for th
 ## Requirements
 
 * Requires PHP 7.4+.
-* Requires WordPress 6.5+.
+* Requires WordPress 6.6+.
 * Ad blockers may break syntax highlighting and pre-save error checking on the edit screen. See [#20](https://github.com/10up/ads-txt/issues/20).
 * Rewrites need to be enabled. Without rewrites, WordPress cannot know to supply `/ads.txt` when requested.
 * Your site URL must not contain a path (e.g. `https://example.com/site/` or path-based multisite installs). While the plugin will appear to function in the admin, it will not display the contents at `https://example.com/site/ads.txt`. This is because the plugin follows the IAB spec, which requires that the ads.txt file be located at the root of a domain or subdomain.

--- a/ads-txt.php
+++ b/ads-txt.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://github.com/10up/ads-txt
  * Description:       Create, manage, and validate your Ads.txt from within WordPress, just like any other content asset. Requires PHP 7.4+ and WordPress 5.7+.
  * Version:           1.4.5
- * Requires at least: 6.5
+ * Requires at least: 6.6
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Ads.txt Manager ===
 Contributors:      10up, helen, adamsilverstein, jakemgold, peterwilsoncc, jeffpaul
 Tags:              ads.txt, app-ads.txt, ads, ad manager, advertising
-Tested up to:      6.7
+Tested up to:      6.8
 Stable tag:        1.4.5
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html
@@ -10,7 +10,7 @@ Create, manage, and validate your ads.txt and app-ads.txt from within WordPress,
 
 == Description ==
 
-Create, manage, and validate your ads.txt and app-ads.txt from within WordPress, like any other content asset. Requires PHP 7.4+ and WordPress 5.7+.
+Create, manage, and validate your ads.txt and app-ads.txt from within WordPress, like any other content asset. Requires PHP 7.4+.
 
 === What is ads.txt? ===
 
@@ -19,7 +19,6 @@ Ads.txt is an initiative by the Interactive Advertising Bureau to enable publish
 === Technical Notes ===
 
 * Requires PHP 7.4+.
-* Requires WordPress 6.3+.
 * Ad blockers may break syntax highlighting and pre-save error checking on the edit screen.
 * Rewrites need to be enabled. Without rewrites, WordPress cannot know to supply `/ads.txt` when requested.
 * Your site URL must not contain a path (e.g. `https://example.com/site/` or path-based multisite installs). While the plugin will appear to function in the admin, it will not display the contents at `https://example.com/site/ads.txt`. This is because the plugin follows the IAB spec, which requires that the ads.txt file be located at the root of a domain or subdomain.


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR bumps the WP tested-up-to 6.8 and WP min to 6.6.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #191.

### How to test the Change
Tested via https://github.com/10up/ads-txt/issues/191#issuecomment-2828619911, but should check that e2e tests here as well.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Bump WordPress "tested up to" version 6.8.
> Changed - Bump WordPress minimum supported version to 6.6.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
