### PR TITLE
Fix/workflow perms

### DIFF
--- a/.github/workflows/build-release-zip.yml
+++ b/.github/workflows/build-release-zip.yml
@@ -1,5 +1,8 @@
 name: Build release zip
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   workflow_call:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,8 @@
 name: End-to-end Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -1,5 +1,8 @@
 name: Lint PHP
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/php8-compatibility.yml
+++ b/.github/workflows/php8-compatibility.yml
@@ -1,5 +1,8 @@
 name: PHP Compatibility
 
+permissions:
+  contents: read
+
 env:
   COMPOSER_VERSION: "2"
   COMPOSER_CACHE: "${{ github.workspace }}/.composer-cache"

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,5 +1,8 @@
 name: Unit Tests
 
+permissions:
+  contents: read
+
 env:
   COMPOSER_VERSION: "2"
   COMPOSER_CACHE: "${{ github.workspace }}/.composer-cache"

--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -1,4 +1,6 @@
 name: Plugin asset/readme update
+permissions:
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy to WordPress.org
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:

--- a/.github/workflows/repo-automator.yml
+++ b/.github/workflows/repo-automator.yml
@@ -1,4 +1,8 @@
 name: 'Repo Automator'
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 on:
   issues:
     types:


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This pull request updates permissions in several GitHub Actions workflows to explicitly define access levels required for their operations. The changes ensure that workflows have the appropriate permissions for reading repository contents and, in some cases, writing to issues and pull requests.

### Permissions updates across workflows:

* [`.github/workflows/build-release-zip.yml`](diffhunk://#diff-948bce84fd4ffebcbf8f82de6162123178817db71cecfb56a7fa79a9535676ecR3-R5): Added `contents: read` permission to enable reading repository contents for the release zip build process.
* [`.github/workflows/cypress.yml`](diffhunk://#diff-5da9a41590fb261de0e464c95862528100c42c77dffad53b7c6de228b6afd2bdR3-R5): Added `contents: read` permission for end-to-end testing workflow.
* [`.github/workflows/lint-php.yml`](diffhunk://#diff-931bfdfcfdadfc9685f2d544c3d0f533098b1b58e0f9fb070d747869971de4aaR3-R5): Added `contents: read` permission for PHP linting workflow.
* [`.github/workflows/php8-compatibility.yml`](diffhunk://#diff-25b21cfa484b2be81080e08bd6e3d891204fe8952abc12e062df99262abf1975R3-R5): Added `contents: read` permission for PHP 8 compatibility checks.
* [`.github/workflows/phpunit.yml`](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510R3-R5): Added `contents: read` permission for unit testing workflow.
* [`.github/workflows/push-asset-readme-update.yml`](diffhunk://#diff-da3ba00836cc30a1497ac5cd5b51eba2baa577ae0a53e64a2263cc6f849e444bR2-R3): Added `contents: read` permission for plugin asset/readme update workflow.
* [`.github/workflows/push-deploy.yml`](diffhunk://#diff-d71c3ba30cee07edf9485b33d2e7ee90f8abcb8c853798bea3437187ebb055bbR3-R5): Added `contents: read` permission for deployment to WordPress.org.

### Additional permissions for automation:

* [`.github/workflows/repo-automator.yml`](diffhunk://#diff-1c38000792e37fe51624d4be0089820da8c58940b859fbbc85561037d1a07118R2-R5): Added `contents: read`, `issues: write`, and `pull-requests: write` permissions to support repository automation tasks such as managing issues and pull requests.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

n/a

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
