### PR TITLE
Replace substr and strpos with str_starts_with for better readability

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -14,7 +14,7 @@ namespace AdsTxt;
  */
 function display_ads_txt() {
 	$request = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : false;
-	if ( '/ads.txt' === $request || '/ads.txt?' === substr( $request, 0, 9 ) ) {
+	if ( '/ads.txt' === $request || str_starts_with( $request, '/ads.txt?' ) ) {
 		$post_id = get_option( ADS_TXT_MANAGER_POST_OPTION );
 
 		// Set custom header for ads-txt
@@ -41,7 +41,7 @@ function display_ads_txt() {
 			echo esc_html( apply_filters( 'ads_txt_content', $adstxt ) );
 			die();
 		}
-	} elseif ( '/app-ads.txt' === $request || '/app-ads.txt?' === substr( $request, 0, 13 ) ) {
+	} elseif ( '/app-ads.txt' === $request || str_starts_with( $request, '/app-ads.txt?' ) ) {
 		$post_id = get_option( APP_ADS_TXT_MANAGER_POST_OPTION );
 
 		// Set custom header for ads-txt

--- a/inc/save.php
+++ b/inc/save.php
@@ -138,7 +138,7 @@ function validate_line( $line, $line_number, $has_only_placeholder_records = nul
 	if ( empty( $line ) ) {
 		$sanitized       = '';
 		$is_empty_record = true;
-	} elseif ( 0 === strpos( $line, '#' ) ) { // This is a full-line comment.
+	} elseif ( str_starts_with( $line, '#' ) ) { // This is a full-line comment.
 		$sanitized  = wp_strip_all_tags( $line );
 		$is_comment = true;
 	} elseif ( 1 < strpos( $line, '=' ) ) { // This is a variable declaration.

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -11,6 +11,9 @@ define( 'TEST_PLUGIN_DIR', dirname( dirname( __DIR__ ) ) . '/' );
 // First we need to load the composer autoloader so we can use WP Mock.
 require_once TEST_PLUGIN_DIR . '/vendor/autoload.php';
 
+// Compatibility shims for PHP functions polyfilled by WordPress.
+require_once __DIR__ . '/compat.php';
+
 // Now call the bootstrap method of WP Mock.
 WP_Mock::bootstrap();
 

--- a/tests/unit/compat.php
+++ b/tests/unit/compat.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Compatibility shims for use by WP_Mock.
+ *
+ * This file contains compatibility PHP shims that are included in WordPress Core
+ * but are not included in the minimum supported version of PHP.
+ *
+ * These are sourced from the WordPress file `wp-includes/compat.php`.
+ *
+ * @package Ads.txt
+ */
+
+if ( ! function_exists( 'str_contains' ) ) {
+	/**
+	 * Polyfill for `str_contains()` function added in PHP 8.0.
+	 *
+	 * Performs a case-sensitive check indicating if needle is
+	 * contained in haystack.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param string $haystack The string to search in.
+	 * @param string $needle   The substring to search for in the `$haystack`.
+	 * @return bool True if `$needle` is in `$haystack`, otherwise false.
+	 */
+	function str_contains( $haystack, $needle ) {
+		if ( '' === $needle ) {
+			return true;
+		}
+
+		return false !== strpos( $haystack, $needle );
+	}
+}
+
+if ( ! function_exists( 'str_starts_with' ) ) {
+	/**
+	 * Polyfill for `str_starts_with()` function added in PHP 8.0.
+	 *
+	 * Performs a case-sensitive check indicating if
+	 * the haystack begins with needle.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param string $haystack The string to search in.
+	 * @param string $needle   The substring to search for in the `$haystack`.
+	 * @return bool True if `$haystack` starts with `$needle`, otherwise false.
+	 */
+	function str_starts_with( $haystack, $needle ) {
+		if ( '' === $needle ) {
+			return true;
+		}
+
+		return 0 === strpos( $haystack, $needle );
+	}
+}
+
+if ( ! function_exists( 'str_ends_with' ) ) {
+	/**
+	 * Polyfill for `str_ends_with()` function added in PHP 8.0.
+	 *
+	 * Performs a case-sensitive check indicating if
+	 * the haystack ends with needle.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param string $haystack The string to search in.
+	 * @param string $needle   The substring to search for in the `$haystack`.
+	 * @return bool True if `$haystack` ends with `$needle`, otherwise false.
+	 */
+	function str_ends_with( $haystack, $needle ) {
+		if ( '' === $haystack ) {
+			return '' === $needle;
+		}
+
+		$len = strlen( $needle );
+
+		return substr( $haystack, -$len, $len ) === $needle;
+	}
+}


### PR DESCRIPTION
### Description of the Change
This pull request refactors several string comparison operations to use the more readable and modern `str_starts_with()` function instead of manual `substr` or `strpos` checks. This improves code clarity and consistency when checking for specific string prefixes.

**Edit:**
`str_starts_with` was introduced with PHP 8.0 and polyfilled in WordPress 5.9

The plugin minimum is: 
* PHP: 7.4
* WordPress: 6.6

So we need to increase the WordPress or PHP minimum to merge the PR.

### Changelog Entry
> Developer - Replace `substr` and `strpos` with `str_starts_with` for better readability


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
